### PR TITLE
feat(api): Add releases/release api calls

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.sentrysentry_mobile">
+    package="io.sentry.sentry_mobile">
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that
          calls FlutterMain.startInitialization(this); in its onCreate method.
          In most cases you can leave this as-is, but you if you want to provide

--- a/lib/api/sentry_api.dart
+++ b/lib/api/sentry_api.dart
@@ -27,7 +27,7 @@ class SentryApi {
       'flatten': '$flatten',
       'summaryStatsPeriod': summaryStatsPeriod,
     };
-    return client.get(Uri.https(baseUrl, '/releases/$projectId', queryParameters),
+    return client.get(Uri.https('sentry.io', '/api/0/organizations/$projectId/releases/', queryParameters),
         headers: {'Cookie': session.toString()}
     );
   }

--- a/lib/api/sentry_api.dart
+++ b/lib/api/sentry_api.dart
@@ -12,12 +12,26 @@ class SentryApi {
 
   Future<Response> organizations() async {
     return client.get('$baseUrl/organizations/?member=1',
-        headers: {'Cookie': session.toString()});
+        headers: {'Cookie': session.toString()}
+    );
   }
 
-  Future<Response> projects(Organization organization) async {
-    return client.get('$baseUrl/organizations/${organization.slug}/projects/',
-        headers: {'Cookie': session.toString()});
+  Future<Response> projects(String slug) async {
+    return client.get('$baseUrl/organizations/$slug/projects/',
+        headers: {'Cookie': session.toString()}
+    );
+  }
+
+  Future<Response> releases(String projectId, {int perPage = 25, int health = 1, int flatten = 0, String summaryStatsPeriod = '24h'}) async {
+    final queryParameters = {
+      'perPage': '$perPage',
+      'health': '$health',
+      'flatten': '$flatten',
+      'summaryStatsPeriod': summaryStatsPeriod,
+    };
+    return client.get(Uri.https(baseUrl, '/releases/$projectId', queryParameters),
+        headers: {'Cookie': session.toString()}
+    );
   }
 
   void close() {

--- a/lib/api/sentry_api.dart
+++ b/lib/api/sentry_api.dart
@@ -34,6 +34,16 @@ class SentryApi {
     );
   }
 
+  Future<Response> release(String projectId, String releaseId, {int health = 1, String summaryStatsPeriod = '24h'}) async {
+    final queryParameters = {
+      'health': '$health',
+      'summaryStatsPeriod': summaryStatsPeriod,
+    };
+    return client.get(Uri.https(baseUrlName, '$baseUrlPath/organizations/$projectId/releases/$releaseId/', queryParameters),
+        headers: _defaultHeader()
+    );
+  }
+
   void close() {
     client.close();
   }

--- a/lib/api/sentry_api.dart
+++ b/lib/api/sentry_api.dart
@@ -6,17 +6,19 @@ class SentryApi {
 
   final Cookie session;
   final client = Client();
-  final baseUrl = 'https://sentry.io/api/0';
+  final baseUrlScheme = 'https://';
+  final baseUrlName = 'sentry.io';
+  final baseUrlPath = '/api/0';
 
   Future<Response> organizations() async {
-    return client.get('$baseUrl/organizations/?member=1',
-        headers: {'Cookie': session.toString()}
+    return client.get('${_baseUrl()}/organizations/?member=1',
+        headers: _defaultHeader()
     );
   }
 
   Future<Response> projects(String slug) async {
-    return client.get('$baseUrl/organizations/$slug/projects/',
-        headers: {'Cookie': session.toString()}
+    return client.get('${_baseUrl()}/organizations/$slug/projects/',
+        headers: _defaultHeader()
     );
   }
 
@@ -27,12 +29,22 @@ class SentryApi {
       'flatten': '$flatten',
       'summaryStatsPeriod': summaryStatsPeriod,
     };
-    return client.get(Uri.https('sentry.io', '/api/0/organizations/$projectId/releases/', queryParameters),
-        headers: {'Cookie': session.toString()}
+    return client.get(Uri.https(baseUrlName, '$baseUrlPath/organizations/$projectId/releases/', queryParameters),
+        headers: _defaultHeader()
     );
   }
 
   void close() {
     client.close();
+  }
+
+  // Helper
+
+  String _baseUrl() {
+    return '$baseUrlScheme$baseUrlName$baseUrlPath';
+  }
+
+  Map<String, String> _defaultHeader() {
+    return {'Cookie': session.toString()};
   }
 }

--- a/lib/api/sentry_api.dart
+++ b/lib/api/sentry_api.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+import 'package:http/http.dart';
+
+import 'package:sentry_mobile/types/organization.dart';
+
+class SentryApi {
+  SentryApi(this.session);
+
+  final Cookie session;
+  final client = Client();
+  final baseUrl = 'https://sentry.io/api/0';
+
+  Future<Response> organizations() async {
+    return client.get('$baseUrl/organizations/?member=1',
+        headers: {'Cookie': session.toString()});
+  }
+
+  Future<Response> projects(Organization organization) async {
+    return client.get('$baseUrl/organizations/${organization.slug}/projects/',
+        headers: {'Cookie': session.toString()});
+  }
+
+  void close() {
+    client.close();
+  }
+}

--- a/lib/api/sentry_api.dart
+++ b/lib/api/sentry_api.dart
@@ -1,8 +1,6 @@
 import 'dart:io';
 import 'package:http/http.dart';
 
-import 'package:sentry_mobile/types/organization.dart';
-
 class SentryApi {
   SentryApi(this.session);
 

--- a/lib/redux/actions.dart
+++ b/lib/redux/actions.dart
@@ -77,3 +77,18 @@ class FetchReleasesSuccessAction {
 class FetchReleasesFailureAction {
   FetchReleasesFailureAction();
 }
+
+class FetchReleaseAction {
+  FetchReleaseAction(this.projectId, this.releaseId);
+  final String projectId;
+  final String releaseId;
+}
+
+class FetchReleaseSuccessAction {
+  FetchReleaseSuccessAction(this.payload);
+  final Release payload;
+}
+
+class FetchReleaseFailureAction {
+  FetchReleaseFailureAction();
+}

--- a/lib/redux/actions.dart
+++ b/lib/redux/actions.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:sentry_mobile/types/organization.dart';
 import 'package:sentry_mobile/types/project.dart';
+import 'package:sentry_mobile/types/release.dart';
 
 class RehydrateAction {
   RehydrateAction();
@@ -61,4 +62,18 @@ class FetchProjectsFailureAction {
 class SelectProjectAction {
   SelectProjectAction(this.payload);
   final Project payload;
+}
+
+class FetchReleasesAction {
+  FetchReleasesAction(this.projectId);
+  final String projectId;
+}
+
+class FetchReleasesSuccessAction {
+  FetchReleasesSuccessAction(this.payload);
+  final List<Release> payload;
+}
+
+class FetchReleasesFailureAction {
+  FetchReleasesFailureAction();
 }

--- a/lib/redux/middlewares.dart
+++ b/lib/redux/middlewares.dart
@@ -69,6 +69,21 @@ void apiMiddleware(
     }
   }
 
+  if (action is FetchReleaseAction) {
+    try {
+      final response = await api.release(action.projectId, action.releaseId);
+      if (response.statusCode == 200) {
+        final responseJson = json.decode(response.body) as Map<String, dynamic>;
+        final release = Release.fromJson(responseJson);
+        store.dispatch(FetchReleaseSuccessAction(release));
+      } else {
+        store.dispatch(FetchReleaseFailureAction());
+      }
+    } catch (e) {
+      store.dispatch(FetchReleaseFailureAction());
+    }
+  }
+
   api.close();
   next(action);
 }

--- a/lib/redux/middlewares.dart
+++ b/lib/redux/middlewares.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:http/http.dart';
+
 import 'package:redux/redux.dart';
 import 'package:sentry_mobile/redux/actions.dart';
 import 'package:sentry_mobile/redux/state/app_state.dart';
@@ -10,31 +10,7 @@ import 'package:sentry_mobile/types/organization.dart';
 import 'package:sentry_mobile/types/project.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-class SentryApi {
-  SentryApi(this.session);
-
-  final Cookie session;
-  final client = Client();
-  final baseUrl = 'https://sentry.io/api/0';
-
-  Future<Response> organizations() async {
-    return client.get('$baseUrl/organizations/?member=1',
-        headers: {'Cookie': session.toString()});
-  }
-
-  Future<Response> me() async {
-    return client.get('$baseUrl/me/', headers: {'Cookie': session.toString()});
-  }
-
-  Future<Response> projects(Organization organization) async {
-    return client.get('$baseUrl/organizations/${organization.slug}/projects/',
-        headers: {'Cookie': session.toString()});
-  }
-
-  void close() {
-    client.close();
-  }
-}
+import 'package:sentry_mobile/api/sentry_api.dart';
 
 void apiMiddleware(
     Store<AppState> store, dynamic action, NextDispatcher next) async {

--- a/lib/redux/middlewares.dart
+++ b/lib/redux/middlewares.dart
@@ -8,6 +8,7 @@ import 'package:sentry_mobile/redux/actions.dart';
 import 'package:sentry_mobile/redux/state/app_state.dart';
 import 'package:sentry_mobile/types/organization.dart';
 import 'package:sentry_mobile/types/project.dart';
+import 'package:sentry_mobile/types/release.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:sentry_mobile/api/sentry_api.dart';
@@ -49,6 +50,22 @@ void apiMiddleware(
       }
     } catch (e) {
       store.dispatch(FetchProjectsFailureAction());
+    }
+  }
+
+  if (action is FetchReleasesAction) {
+    try {
+      final response = await api.releases(action.projectId);
+      if (response.statusCode == 200) {
+        final responseJson = json.decode(response.body) as List;
+        final releaseList = List<Map<String, dynamic>>.from(responseJson);
+        final releases = releaseList.map((Map<String, dynamic> r) => Release.fromJson(r)).toList();
+        store.dispatch(FetchReleasesSuccessAction(releases));
+      } else {
+        store.dispatch(FetchReleasesFailureAction());
+      }
+    } catch (e) {
+      store.dispatch(FetchReleasesFailureAction());
     }
   }
 

--- a/lib/redux/middlewares.dart
+++ b/lib/redux/middlewares.dart
@@ -37,7 +37,7 @@ void apiMiddleware(
 
   if (action is FetchProjectsAction) {
     try {
-      final response = await api.projects(action.payload);
+      final response = await api.projects(action.payload.slug);
       if (response.statusCode == 200) {
         final responseJson = json.decode(response.body) as List;
         final projList = List<Map<String, dynamic>>.from(responseJson);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,14 +28,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.0-nullsafety.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   build:
     dependency: transitive
     description:
@@ -98,14 +98,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0-nullsafety.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -126,7 +126,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0-nullsafety.1"
   code_builder:
     dependency: transitive
     description:
@@ -140,7 +140,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.13"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: transitive
     description:
@@ -189,7 +189,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   file:
     dependency: transitive
     description:
@@ -344,14 +344,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.8"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0-nullsafety.3"
   mime:
     dependency: transitive
     description:
@@ -393,7 +393,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.1"
   path_provider:
     dependency: transitive
     description:
@@ -566,21 +566,21 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.5"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.1"
   stream_transform:
     dependency: transitive
     description:
@@ -594,21 +594,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0-nullsafety.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.17"
+    version: "0.2.19-nullsafety.2"
   timeago:
     dependency: "direct main"
     description:
@@ -629,7 +629,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0-nullsafety.3"
   url_launcher:
     dependency: "direct main"
     description:
@@ -671,7 +671,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.1.0-nullsafety.3"
   watcher:
     dependency: transitive
     description:
@@ -715,5 +715,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.9.0-14.0.dev <3.0.0"
+  dart: ">=2.10.0-110 <2.11.0"
   flutter: ">=1.17.0 <2.0.0"


### PR DESCRIPTION
## Description

Add the API calls for releases and for a single release.

Closes #4 

## Details

- I have not yet extended the `Releases` model class yet with all properties returned from the API, as we might not need all of them anyway.
- Had an issue deploying to Android devices which was also fixed.
- Will refactor the API client in a future PR to encapsulate JSON parsing and error handling internally.

## Testing

- Dispatch the `FetchReleasesAction` or `FetchReleaseAction` at a appropriate place in the applications code to test the calls.