### PR TITLE
fix(layout): Long titles in card break layout

### DIFF
--- a/lib/screens/release_health/release_card.dart
+++ b/lib/screens/release_health/release_card.dart
@@ -45,9 +45,13 @@ class ReleaseCard extends StatelessWidget {
                 padding: const EdgeInsets.only(left: 16, top: 20, right: 16, bottom: 0),
                 child: Align(
                   alignment: Alignment.centerLeft,
-                  child: Text(
-                    release.version,
-                    style: Theme.of(context).textTheme.headline5,
+                  child: FittedBox(
+                    fit: BoxFit.cover,
+                    child: Text(
+                      release.version,
+                      maxLines: 2,
+                      style: Theme.of(context).textTheme.headline5,
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
Closes #51 

# Assets

<img width="715" alt="Bildschirmfoto 2020-12-30 um 10 30 52" src="https://user-images.githubusercontent.com/3984453/103342771-ad65bc00-4a8a-11eb-9fff-ad04a3752385.png">
