### PR TITLE
enha(main): Improve issues/crashes graph baseline

### DIFF
--- a/lib/screens/chart/line_chart.dart
+++ b/lib/screens/chart/line_chart.dart
@@ -7,25 +7,26 @@ import 'line_chart_data.dart';
 import 'line_chart_point.dart';
 
 class LineChart extends StatelessWidget {
-  LineChart({@required this.data, @required this.lineWidth, @required this.lineColor, @required this.gradientStart, @required this.gradientEnd});
+  LineChart({@required this.data, @required this.lineWidth, @required this.lineColor, @required this.gradientStart, @required this.gradientEnd, this.cubicLines});
 
   final LineChartData data;
   final double lineWidth;
   final Color lineColor;
   final Color gradientStart;
   final Color gradientEnd;
+  final bool cubicLines;
 
   @override
   Widget build(BuildContext context) {
     return CustomPaint(
-      painter: _LineChartPainter.create(data, lineWidth, lineColor, gradientStart, gradientEnd),
+      painter: _LineChartPainter.create(data, lineWidth, lineColor, gradientStart, gradientEnd, cubicLines),
       child: Center(),
     );
   }
 }
 
 class _LineChartPainter extends CustomPainter {
-  _LineChartPainter.create(this.data, double lineWidth, Color lineColor, this.gradientStart, this.gradientEnd) {
+  _LineChartPainter.create(this.data, double lineWidth, Color lineColor, this.gradientStart, this.gradientEnd, this.cubicLines) {
     linePaint = Paint()
       ..isAntiAlias = true
       ..style = PaintingStyle.stroke
@@ -39,6 +40,7 @@ class _LineChartPainter extends CustomPainter {
   double linePadding;
   Color gradientStart;
   Color gradientEnd;
+  bool cubicLines;
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -87,7 +89,7 @@ class _LineChartPainter extends CustomPainter {
       final cx2 = (x1 + x2) / 2;
       final cy2 = y2;
 
-      if (y1 == y2) {
+      if (y1 == y2 || !cubicLines) {
         linePath.lineTo(x2, flipY(y2));
       } else {
         linePath.cubicTo(cx1, flipY(cy1), cx2, flipY(cy2), x2, flipY(y2));

--- a/lib/screens/release_health/release_card.dart
+++ b/lib/screens/release_health/release_card.dart
@@ -93,7 +93,8 @@ class ReleaseCard extends StatelessWidget {
                           lineWidth: 5.0,
                           lineColor: Colors.black.withOpacity(0.05),
                           gradientStart: Colors.transparent,
-                          gradientEnd: Colors.transparent
+                          gradientEnd: Colors.transparent,
+                          cubicLines: false
                         ),
                       ),
                       Padding(
@@ -103,7 +104,8 @@ class ReleaseCard extends StatelessWidget {
                             lineWidth: 5.0,
                             lineColor: Colors.white,
                             gradientStart: Colors.transparent,
-                            gradientEnd: Colors.transparent
+                            gradientEnd: Colors.transparent,
+                            cubicLines: false
                         ),
                       ),
                     ]

--- a/lib/screens/release_health/release_health_chart_row.dart
+++ b/lib/screens/release_health/release_health_chart_row.dart
@@ -69,7 +69,8 @@ class ReleaseHealthChartRow extends StatelessWidget {
                       lineWidth: 2.0,
                       lineColor: SentryColors.tapestry,
                       gradientStart: SentryColors.tapestry.withAlpha(84),
-                      gradientEnd: SentryColors.tapestry.withAlpha(28)
+                      gradientEnd: SentryColors.tapestry.withAlpha(28),
+                      cubicLines: false
                   ),
                   height: 35,
                 )

--- a/lib/screens/release_health/release_health_chart_row.dart
+++ b/lib/screens/release_health/release_health_chart_row.dart
@@ -68,8 +68,8 @@ class ReleaseHealthChartRow extends StatelessWidget {
                       data: viewModel.data,
                       lineWidth: 2.0,
                       lineColor: SentryColors.tapestry,
-                      gradientStart: SentryColors.tapestry.withAlpha(28),
-                      gradientEnd: Colors.transparent
+                      gradientStart: SentryColors.tapestry.withAlpha(84),
+                      gradientEnd: SentryColors.tapestry.withAlpha(28)
                   ),
                   height: 35,
                 )


### PR DESCRIPTION
- Don't draw graph gradient to transparent color, so zero baseline is visible
- Draw straight graph lines to match current Figma design

Closes #89