### PR TITLE
feat(sessions): Show all session charts

### DIFF
--- a/lib/api/sentry_api.dart
+++ b/lib/api/sentry_api.dart
@@ -129,7 +129,7 @@ class SentryApi {
     @required String organizationSlug,
     @required String projectId,
     @required String field,
-    String statsPeriod = '12h',
+    String statsPeriod = '24h',
     String interval = '1h',
     String groupBy,
     String statsPeriodStart,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -120,9 +120,9 @@ class SentryMobile extends StatelessWidget {
                     color: SentryColors.mamba,
                   ),
                   caption: TextStyle(
-                    fontWeight: FontWeight.w500,
-                    fontSize: 16,
-                    color: Colors.black45,
+                    fontWeight: FontWeight.normal,
+                    fontSize: 12,
+                    color: SentryColors.mamba,
                   )),
             )),
         home: StoreConnector<AppState, AppState>(

--- a/lib/redux/actions.dart
+++ b/lib/redux/actions.dart
@@ -19,8 +19,9 @@ class RehydrateAction {
 }
 
 class RehydrateSuccessAction {
-  RehydrateSuccessAction(this.cookie);
+  RehydrateSuccessAction(this.cookie, this.version);
   final Cookie cookie;
+  final String version;
 }
 
 class SwitchTabAction {

--- a/lib/redux/middlewares.dart
+++ b/lib/redux/middlewares.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:package_info/package_info.dart';
 import 'package:redux/redux.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:webview_cookie_manager/webview_cookie_manager.dart';
@@ -209,7 +210,9 @@ class LocalStorageMiddleware extends MiddlewareClass<AppState> {
       } catch (e) {
         await secureStorage.delete(key: 'session');
       }
-      store.dispatch(RehydrateSuccessAction(cookie));
+      final packageInfo = await PackageInfo.fromPlatform();
+      final version = 'Version ${packageInfo.version} (${packageInfo.buildNumber})';
+      store.dispatch(RehydrateSuccessAction(cookie, version));
     }
     if (action is LoginAction) {
       await secureStorage.write(key: 'session', value: action.cookie.toString());

--- a/lib/redux/middlewares.dart
+++ b/lib/redux/middlewares.dart
@@ -138,8 +138,8 @@ class SentryApiMiddleware extends MiddlewareClass<AppState> {
             projectId: action.projectId,
             field: SessionGroup.sumSessionKey,
             groupBy: SessionGroupBy.sessionStatusKey,
-            statsPeriodStart: '24h',
-            statsPeriodEnd: '12h'
+            statsPeriodStart: '48h',
+            statsPeriodEnd: '24h'
           );
 
           store.dispatch(
@@ -158,14 +158,14 @@ class SentryApiMiddleware extends MiddlewareClass<AppState> {
         try {
 
           final now = DateTime.now();
-          final twelveHoursAgo = now.add(Duration(hours: -12));
           final twentyFourHoursAgo = now.add(Duration(hours: -24));
+          final fortyEightHoursAgo = now.add(Duration(hours: -48));
 
           final apdex = await api.apdex(
             apdexThreshold: action.apdexThreshold,
             organizationSlug: action.organizationSlug,
             projectId: action.projectId,
-            start: twelveHoursAgo,
+            start: twentyFourHoursAgo,
             end: now
           );
 
@@ -173,8 +173,8 @@ class SentryApiMiddleware extends MiddlewareClass<AppState> {
               apdexThreshold: action.apdexThreshold,
               organizationSlug: action.organizationSlug,
               projectId: action.projectId,
-              start: twentyFourHoursAgo,
-              end: twelveHoursAgo
+              start: fortyEightHoursAgo,
+              end: twentyFourHoursAgo
           );
 
           store.dispatch(

--- a/lib/redux/reducers.dart
+++ b/lib/redux/reducers.dart
@@ -37,7 +37,7 @@ GlobalState _switchTabAction(GlobalState state, SwitchTabAction action) {
 }
 
 GlobalState _rehydrateSuccessAction(GlobalState state, RehydrateSuccessAction action) {
-  return state.copyWith(hydrated: true, session: action.cookie);
+  return state.copyWith(hydrated: true, session: action.cookie, version: action.version);
 }
 
 GlobalState _loginAction(GlobalState state, LoginAction action) {

--- a/lib/redux/state/app_state.dart
+++ b/lib/redux/state/app_state.dart
@@ -32,6 +32,7 @@ class GlobalState {
   GlobalState(
       {this.session,
       this.hydrated,
+      this.version,
       this.selectedTab,
       this.organizations,
       this.organizationsSlugByProjectSlug,
@@ -56,6 +57,7 @@ class GlobalState {
     return GlobalState(
       session: null,
       hydrated: false,
+      version: '--',
       selectedTab: 0,
       organizations: [],
       organizationsSlugByProjectSlug: {},
@@ -80,6 +82,7 @@ class GlobalState {
 
   final Cookie session;
   final bool hydrated;
+  final String version;
   final int selectedTab;
 
   final List<Organization> organizations;
@@ -109,6 +112,7 @@ class GlobalState {
   GlobalState copyWith({
     Cookie session,
     bool hydrated,
+    String version,
     int selectedTab,
     bool setSessionNull = false,
     List<Organization> organizations,
@@ -133,6 +137,7 @@ class GlobalState {
     return GlobalState(
       session: setSessionNull ? null : (session ?? this.session),
       hydrated: hydrated ?? this.hydrated,
+      version: version ?? this.version,
       selectedTab: selectedTab ?? this.selectedTab,
       organizations: organizations ?? this.organizations,
       organizationsSlugByProjectSlug: organizationsSlugByProjectSlug ?? this.organizationsSlugByProjectSlug,

--- a/lib/redux/state/app_state.dart
+++ b/lib/redux/state/app_state.dart
@@ -201,10 +201,10 @@ class GlobalState {
       if (sessions != null) {
         sessionStateByProjectId[projectId] = SessionState(
           projectId: projectId,
-          sessionCount: total,
-          previousSessionCount: previousTotal,
-          points: lineChartPoints,
-          previousPoints: previousLineChartPoints
+          numberOfSessions: total,
+          previousNumberOfSessions: previousTotal,
+          sessionPoints: lineChartPoints,
+          previousSessionPoints: previousLineChartPoints
         );
       }
     }

--- a/lib/redux/state/session_state.dart
+++ b/lib/redux/state/session_state.dart
@@ -5,17 +5,17 @@ import '../../screens/chart/line_chart_point.dart';
 class SessionState {
   SessionState({
     @required this.projectId,
-    @required this.sessionCount,
-    @required this.previousSessionCount,
-    @required this.points,
-    @required this.previousPoints
+    @required this.numberOfSessions,
+    @required this.previousNumberOfSessions,
+    @required this.sessionPoints,
+    @required this.previousSessionPoints
   });
 
   final String projectId;
 
-  final int sessionCount;
-  final int previousSessionCount;
+  final int numberOfSessions;
+  final int previousNumberOfSessions;
 
-  final List<LineChartPoint> points;
-  final List<LineChartPoint> previousPoints;
+  final List<LineChartPoint> sessionPoints;
+  final List<LineChartPoint> previousSessionPoints;
 }

--- a/lib/screens/chart/line_chart_point.dart
+++ b/lib/screens/chart/line_chart_point.dart
@@ -1,4 +1,3 @@
-
 import 'package:equatable/equatable.dart';
 
 class LineChartPoint extends Equatable {

--- a/lib/screens/health/health_screen.dart
+++ b/lib/screens/health/health_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
 import 'package:sentry_mobile/types/session_status.dart';
+import 'package:sentry_mobile/utils/sentry_colors.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../redux/state/app_state.dart';
@@ -123,18 +124,22 @@ class _HealthScreenState extends State<HealthScreen> {
                           ),
                           SessionsChartRow(
                             title: 'Healthy',
+                            color: SentryColors.meatBrown,
                             sessionState: viewModel.sessionState(_index, SessionStatus.healthy),
                           ),
                           SessionsChartRow(
                             title: 'Errored',
+                            color: SentryColors.cornFlowerBlue,
                             sessionState: viewModel.sessionState(_index, SessionStatus.errored),
                           ),
                           SessionsChartRow(
                             title: 'Abnormal',
+                            color: SentryColors.antiqueFuchsia,
                             sessionState: viewModel.sessionState(_index, SessionStatus.abnormal),
                           ),
                           SessionsChartRow(
                             title: 'Crashed',
+                            color: SentryColors.japonica,
                             sessionState: viewModel.sessionState(_index, SessionStatus.crashed),
                           ),
                           HealthDivider(

--- a/lib/screens/health/health_screen.dart
+++ b/lib/screens/health/health_screen.dart
@@ -124,22 +124,22 @@ class _HealthScreenState extends State<HealthScreen> {
                           ),
                           SessionsChartRow(
                             title: 'Healthy',
-                            color: SentryColors.meatBrown,
+                            color: SentryColors.buttercup,
                             sessionState: viewModel.sessionState(_index, SessionStatus.healthy),
                           ),
                           SessionsChartRow(
                             title: 'Errored',
-                            color: SentryColors.cornFlowerBlue,
+                            color: SentryColors.eastBay,
                             sessionState: viewModel.sessionState(_index, SessionStatus.errored),
                           ),
                           SessionsChartRow(
                             title: 'Abnormal',
-                            color: SentryColors.antiqueFuchsia,
+                            color: SentryColors.tapestry,
                             sessionState: viewModel.sessionState(_index, SessionStatus.abnormal),
                           ),
                           SessionsChartRow(
                             title: 'Crashed',
-                            color: SentryColors.japonica,
+                            color: SentryColors.burntSienna,
                             sessionState: viewModel.sessionState(_index, SessionStatus.crashed),
                           ),
                           HealthDivider(

--- a/lib/screens/health/health_screen.dart
+++ b/lib/screens/health/health_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
+import 'package:sentry_mobile/types/session_status.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../redux/state/app_state.dart';
@@ -108,7 +109,7 @@ class _HealthScreenState extends State<HealthScreen> {
                             return ProjectCard(
                                 projectWitLatestRelease.project,
                                 projectWitLatestRelease.release,
-                                viewModel.sessionStateForProject(projectWitLatestRelease.project)
+                                viewModel.totalSessionStateForProject(projectWitLatestRelease.project)
                             );
                           },
                         )),
@@ -118,16 +119,23 @@ class _HealthScreenState extends State<HealthScreen> {
                         children: [
                           HealthDivider(
                             onSeeAll: () {},
-                            title: 'Charts',
+                            title: 'Sessions',
                           ),
                           SessionsChartRow(
-                            title: 'Issues',
-                            sessionState: viewModel.handledAndCrashedSessionStateForProject(viewModel.projects[_index].project),
+                            title: 'Healthy',
+                            sessionState: viewModel.sessionState(_index, SessionStatus.healthy),
                           ),
                           SessionsChartRow(
-                            title: 'Crashes',
-                            sessionState: viewModel.crashedSessionStateForProject(viewModel.projects[_index].project),
-                            parentPoints: viewModel.handledAndCrashedSessionStateForProject(viewModel.projects[_index].project)?.points,
+                            title: 'Errored',
+                            sessionState: viewModel.sessionState(_index, SessionStatus.errored),
+                          ),
+                          SessionsChartRow(
+                            title: 'Abnormal',
+                            sessionState: viewModel.sessionState(_index, SessionStatus.abnormal),
+                          ),
+                          SessionsChartRow(
+                            title: 'Crashed',
+                            sessionState: viewModel.sessionState(_index, SessionStatus.crashed),
                           ),
                           HealthDivider(
                             onSeeAll: () {},

--- a/lib/screens/health/health_screen_view_model.dart
+++ b/lib/screens/health/health_screen_view_model.dart
@@ -80,6 +80,7 @@ class HealthScreenViewModel {
       case SessionStatus.abnormal:
         return _abnormalSessionsStateByProjectId[project.id];
     }
+    return null;
   }
 
   HealthCardViewModel stabilityScoreForProject(Project project) {

--- a/lib/screens/health/health_screen_view_model.dart
+++ b/lib/screens/health/health_screen_view_model.dart
@@ -13,7 +13,7 @@ class HealthScreenViewModel {
     : _store = store,
       projects = store.state.globalState.allOrBookmarkedProjectsWithLatestReleases(),
       _totalSessionStateByProjectId = store.state.globalState.sessionStateByProjectId(SessionStatus.values.toSet()),
-      _healthSessionsStateByProjectId = store.state.globalState.sessionStateByProjectId({SessionStatus.healthy}),
+      _healthySessionsStateByProjectId = store.state.globalState.sessionStateByProjectId({SessionStatus.healthy}),
       _erroredSessionsStateByProjectId = store.state.globalState.sessionStateByProjectId({SessionStatus.errored}),
       _abnormalSessionsStateByProjectId = store.state.globalState.sessionStateByProjectId({SessionStatus.abnormal}),
       _crashedSessionStateByProjectId = store.state.globalState.sessionStateByProjectId({SessionStatus.crashed}),
@@ -36,7 +36,7 @@ class HealthScreenViewModel {
   final List<ProjectWithLatestRelease> projects;
 
   final Map<String, SessionState> _totalSessionStateByProjectId;
-  final Map<String, SessionState> _healthSessionsStateByProjectId;
+  final Map<String, SessionState> _healthySessionsStateByProjectId;
   final Map<String, SessionState> _erroredSessionsStateByProjectId;
   final Map<String, SessionState> _abnormalSessionsStateByProjectId;
   final Map<String, SessionState> _crashedSessionStateByProjectId;
@@ -72,7 +72,7 @@ class HealthScreenViewModel {
 
     switch (sessionStatus) {
       case SessionStatus.healthy:
-        return _healthSessionsStateByProjectId[project.id];
+        return _healthySessionsStateByProjectId[project.id];
       case SessionStatus.errored:
         return _erroredSessionsStateByProjectId[project.id];
       case SessionStatus.crashed:

--- a/lib/screens/health/health_screen_view_model.dart
+++ b/lib/screens/health/health_screen_view_model.dart
@@ -12,8 +12,10 @@ class HealthScreenViewModel {
   HealthScreenViewModel.fromStore(Store<AppState> store)
     : _store = store,
       projects = store.state.globalState.allOrBookmarkedProjectsWithLatestReleases(),
-      _sessionStateByProjectId = store.state.globalState.sessionStateByProjectId(SessionStatus.values.toSet()),
-      _handledAndCrashedSessionStateByProjectId = store.state.globalState.sessionStateByProjectId({SessionStatus.errored, SessionStatus.abnormal, SessionStatus.crashed}),
+      _totalSessionStateByProjectId = store.state.globalState.sessionStateByProjectId(SessionStatus.values.toSet()),
+      _healthSessionsStateByProjectId = store.state.globalState.sessionStateByProjectId({SessionStatus.healthy}),
+      _erroredSessionsStateByProjectId = store.state.globalState.sessionStateByProjectId({SessionStatus.errored}),
+      _abnormalSessionsStateByProjectId = store.state.globalState.sessionStateByProjectId({SessionStatus.abnormal}),
       _crashedSessionStateByProjectId = store.state.globalState.sessionStateByProjectId({SessionStatus.crashed}),
       _stabilityScoreByProjectId = store.state.globalState.stabilityScoreByProjectId,
       _stabilityScoreBeforeByProjectId = store.state.globalState.stabilityScoreBeforeByProjectId,
@@ -33,8 +35,10 @@ class HealthScreenViewModel {
 
   final List<ProjectWithLatestRelease> projects;
 
-  final Map<String, SessionState> _sessionStateByProjectId;
-  final Map<String, SessionState> _handledAndCrashedSessionStateByProjectId;
+  final Map<String, SessionState> _totalSessionStateByProjectId;
+  final Map<String, SessionState> _healthSessionsStateByProjectId;
+  final Map<String, SessionState> _erroredSessionsStateByProjectId;
+  final Map<String, SessionState> _abnormalSessionsStateByProjectId;
   final Map<String, SessionState> _crashedSessionStateByProjectId;
 
   final Map<String, double> _stabilityScoreByProjectId;
@@ -59,18 +63,25 @@ class HealthScreenViewModel {
     _store.dispatch(FetchOrganizationsAndProjectsAction());
   }
 
-  SessionState sessionStateForProject(Project project) {
-    return _sessionStateByProjectId[project.id];
-  }
-
-  SessionState handledAndCrashedSessionStateForProject(Project project) {
-    return _handledAndCrashedSessionStateByProjectId[project.id];
-  }
-
-  SessionState crashedSessionStateForProject(Project project) {
-    return _crashedSessionStateByProjectId[project.id];
+  SessionState totalSessionStateForProject(Project project) {
+    return _totalSessionStateByProjectId[project.id];
   }
   
+  SessionState sessionState(int index, SessionStatus sessionStatus) {
+    final project = projects[index].project;
+
+    switch (sessionStatus) {
+      case SessionStatus.healthy:
+        return _healthSessionsStateByProjectId[project.id];
+      case SessionStatus.errored:
+        return _erroredSessionsStateByProjectId[project.id];
+      case SessionStatus.crashed:
+        return _crashedSessionStateByProjectId[project.id];
+      case SessionStatus.abnormal:
+        return _abnormalSessionsStateByProjectId[project.id];
+    }
+  }
+
   HealthCardViewModel stabilityScoreForProject(Project project) {
     return HealthCardViewModel.stabilityScore(
       _stabilityScoreByProjectId[project.id],

--- a/lib/screens/health/project_card.dart
+++ b/lib/screens/health/project_card.dart
@@ -88,7 +88,7 @@ class ProjectCard extends StatelessWidget {
                       Padding(
                         padding: const EdgeInsets.only(top: 12),
                         child: LineChart(
-                          data: LineChartData.prepareData(points: sessions.points),
+                          data: LineChartData.prepareData(points: sessions.sessionPoints),
                           lineWidth: 5.0,
                           lineColor: Colors.black.withOpacity(0.05),
                           gradientStart: Colors.transparent,
@@ -99,7 +99,7 @@ class ProjectCard extends StatelessWidget {
                       Padding(
                         padding: const EdgeInsets.only(bottom: 12),
                         child: LineChart(
-                            data: LineChartData.prepareData(points: sessions.points),
+                            data: LineChartData.prepareData(points: sessions.sessionPoints),
                             lineWidth: 5.0,
                             lineColor: Colors.white,
                             gradientStart: Colors.transparent,

--- a/lib/screens/health/sessions_chart_row.dart
+++ b/lib/screens/health/sessions_chart_row.dart
@@ -8,16 +8,15 @@ import '../../utils/sentry_colors.dart';
 import '../../utils/sentry_icons.dart';
 
 class SessionsChartRow extends StatelessWidget {
-  SessionsChartRow({@required this.title, @required this.color, @required this.sessionState, this.parentPoints});
+  SessionsChartRow({@required this.title, @required this.color, @required this.sessionState});
 
   final String title;
   final Color color;
   final SessionState sessionState;
-  final List<LineChartPoint> parentPoints;
 
   @override
   Widget build(BuildContext context) {
-    final viewModel = SessionsChartRowViewModel.create(sessionState, parentPoints ?? []);
+    final viewModel = SessionsChartRowViewModel.create(sessionState);
     
     return Container(
         padding: EdgeInsets.only(bottom: 22),

--- a/lib/screens/health/sessions_chart_row.dart
+++ b/lib/screens/health/sessions_chart_row.dart
@@ -8,9 +8,10 @@ import '../../utils/sentry_colors.dart';
 import '../../utils/sentry_icons.dart';
 
 class SessionsChartRow extends StatelessWidget {
-  SessionsChartRow({@required this.title, @required this.sessionState, this.parentPoints});
+  SessionsChartRow({@required this.title, @required this.color, @required this.sessionState, this.parentPoints});
 
   final String title;
+  final Color color;
   final SessionState sessionState;
   final List<LineChartPoint> parentPoints;
 
@@ -57,7 +58,7 @@ class SessionsChartRow extends StatelessWidget {
                         LinearProgressIndicator(
                             minHeight: 2.0,
                             backgroundColor: Colors.white,
-                            valueColor: AlwaysStoppedAnimation<Color>(SentryColors.tapestry)
+                            valueColor: AlwaysStoppedAnimation<Color>(color)
                         )
                       ]
                   ),
@@ -68,9 +69,9 @@ class SessionsChartRow extends StatelessWidget {
                   child: LineChart(
                       data: viewModel.data,
                       lineWidth: 2.0,
-                      lineColor: SentryColors.tapestry,
-                      gradientStart: SentryColors.tapestry.withAlpha(84),
-                      gradientEnd: SentryColors.tapestry.withAlpha(28),
+                      lineColor: color,
+                      gradientStart: color.withAlpha(84),
+                      gradientEnd: color.withAlpha(28),
                       cubicLines: false
                   ),
                   height: 35,

--- a/lib/screens/health/sessions_chart_row.dart
+++ b/lib/screens/health/sessions_chart_row.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 
 import '../../redux/state/session_state.dart';
 import '../../screens/chart/line_chart.dart';
-import '../../screens/chart/line_chart_point.dart';
 import '../../screens/health/sessions_chart_row_view_model.dart';
 import '../../utils/sentry_colors.dart';
 import '../../utils/sentry_icons.dart';

--- a/lib/screens/health/sessions_chart_row.dart
+++ b/lib/screens/health/sessions_chart_row.dart
@@ -39,7 +39,7 @@ class SessionsChartRow extends StatelessWidget {
                         fontWeight: FontWeight.w600,
                         fontSize: 16,
                       ))),
-              Text('Last 12 hours',
+              Text('Last 24 hours',
                   style: TextStyle(
                     color: SentryColors.mamba,
                     fontSize: 12,

--- a/lib/screens/health/sessions_chart_row_view_model.dart
+++ b/lib/screens/health/sessions_chart_row_view_model.dart
@@ -4,12 +4,12 @@ import '../../screens/chart/line_chart_point.dart';
 
 class SessionsChartRowViewModel {
 
-  SessionsChartRowViewModel.create(SessionState sessionState, List<LineChartPoint> parentPoints) {
-    if (sessionState == null || sessionState.points == null) {
+  SessionsChartRowViewModel.create(SessionState sessionState) {
+    if (sessionState == null || sessionState.sessionPoints == null) {
       data = null;
       percentChange = 0.0;
       numberOfIssues = 0;
-    } else if (sessionState.points.length < 2) {
+    } else if (sessionState.sessionPoints.length < 2) {
       data = LineChartData.prepareData(
           points: [
             LineChartPoint(0, 0),
@@ -19,16 +19,11 @@ class SessionsChartRowViewModel {
       percentChange = 0.0;
       numberOfIssues = data.countY.toInt();
     } else {
-
-      if (parentPoints != null && parentPoints.isNotEmpty) {
-        final parent = LineChartData.prepareData(points: parentPoints);
-        data = LineChartData.prepareData(points: sessionState.points, preferredMinY: parent.minY, preferredMaxY: parent.maxY);
-      } else {
-        data = LineChartData.prepareData(points: sessionState.points);
-      }
-
-      if (sessionState.previousSessionCount != null) {
-        percentChange = _percentChange(sessionState.previousSessionCount.toDouble(), sessionState.sessionCount.toDouble());
+      data = LineChartData.prepareData(
+          points: sessionState.sessionPoints
+      );
+      if (sessionState.previousNumberOfSessions != null) {
+        percentChange = _percentChange(sessionState.previousNumberOfSessions.toDouble(), sessionState.numberOfSessions.toDouble());
       } else {
         percentChange = 0.0;
       }

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_redux/flutter_redux.dart';
+import 'package:sentry_mobile/screens/debug/sentry_flutter_screen.dart';
 
 import '../../redux/state/app_state.dart';
 import '../../screens/project_picker/project_picker.dart';
@@ -21,7 +22,7 @@ class _SettingsState extends State<Settings> {
     return StoreConnector<AppState, SettingsViewModel>(
       builder: (_, viewModel) => _content(viewModel),
       converter: (store) => SettingsViewModel.fromStore(store),
-      onInitialBuild: (viewModel) => viewModel.fetchAuthenticatedUserIfNeeded(),
+      onInitialBuild: (viewModel) => viewModel.fetchAuthenticatedUserIfNeeded()
     );
   }
 
@@ -84,7 +85,24 @@ class _SettingsState extends State<Settings> {
                   color: SentryColors.royalBlue,
                 ),
                 onTap: () => Navigator.pop(context, true),
-              )
+              ),
+              Padding(
+                padding: const EdgeInsets.only(top: 32.0),
+                child: GestureDetector(
+                  onLongPress: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          fullscreenDialog: true,
+                          builder: (context) => SentryFlutterScreen()
+                      ),
+                    );
+                  },
+                  child: Text(
+                    viewModel.version,
+                    style: Theme.of(context).textTheme.caption)
+                  )
+              ),
             ],
           ),
         ),

--- a/lib/screens/settings/settings_view_model.dart
+++ b/lib/screens/settings/settings_view_model.dart
@@ -23,12 +23,14 @@ class SettingsViewModel {
     } else {
       userInfo = '--';
     }
+    version = store.state.globalState.version;
   }
 
   Store<AppState> _store;
 
   String bookmarkedProjects;
   String userInfo;
+  String version = '--';
 
   void fetchAuthenticatedUserIfNeeded() {
     if (_store.state.globalState.me == null) {

--- a/lib/utils/sentry_colors.dart
+++ b/lib/utils/sentry_colors.dart
@@ -17,8 +17,6 @@ class SentryColors {
   static const lavenderGray = Color(0xffB9C1D9);
   static const silverChalice = Color(0xffA4A4A4);
 
-  static const tapestry = Color(0xffB85586);
-
   static const wildBlueYonder = Color(0xff8492BA);
 
   static const cruise = Color(0xffB6ECDF);
@@ -28,14 +26,13 @@ class SentryColors {
   static const lightningYellow = Color(0xffFFC227);
 
   static const cupid = Color(0xffFCC6C8);
-  static const burntSienna = Color(0xffEE6855);
 
   static const royalBlue = Color(0xff3D74DB);
 
-  static const meatBrown = Color(0xFFE9B942); // Healthy
-  static const cornFlowerBlue = Color(0xFF444671); // Errored
-  static const antiqueFuchsia = Color(0xFF995886); // Abnormal
-  static const japonica = Color(0xFFDF7767); // Crashed
+  static const buttercup = Color(0xfff2b712); // Healthy
+  static const eastBay = Color(0xff444674); // Errored
+  static const tapestry = Color(0xffa35488); // Abnormal
+  static const burntSienna = Color(0xffef7061); // Crashed
 
   // Util
 

--- a/lib/utils/sentry_colors.dart
+++ b/lib/utils/sentry_colors.dart
@@ -32,6 +32,11 @@ class SentryColors {
 
   static const royalBlue = Color(0xff3D74DB);
 
+  static const meatBrown = Color(0xFFE9B942); // Healthy
+  static const cornFlowerBlue = Color(0xFF444671); // Errored
+  static const antiqueFuchsia = Color(0xFF995886); // Abnormal
+  static const japonica = Color(0xFFDF7767); // Crashed
+
   // Util
 
   static MaterialColor createMaterialColor(Color color) {

--- a/test/screens/release_health/sessions_chart_row_view_model_test.dart
+++ b/test/screens/release_health/sessions_chart_row_view_model_test.dart
@@ -19,10 +19,10 @@ void main() {
 
       final sessionState = SessionState(
           projectId: 'fixture-projectId',
-          sessionCount: 10,
-          previousSessionCount: 5,
-          points: points,
-          previousPoints: pointsBefore
+          numberOfSessions: 10,
+          previousNumberOfSessions: 5,
+          sessionPoints: points,
+          previousSessionPoints: pointsBefore
       );
 
       final sut = SessionsChartRowViewModel.create(sessionState, []);
@@ -44,10 +44,10 @@ void main() {
 
       final sessionState = SessionState(
           projectId: 'fixture-projectId',
-          sessionCount: 10,
-          previousSessionCount: 5,
-          points: points,
-          previousPoints: pointsBefore
+          numberOfSessions: 10,
+          previousNumberOfSessions: 5,
+          sessionPoints: points,
+          previousSessionPoints: pointsBefore
       );
 
       final sut = SessionsChartRowViewModel.create(sessionState, []);
@@ -69,10 +69,10 @@ void main() {
 
       final sessionState = SessionState(
           projectId: 'fixture-projectId',
-          sessionCount: 8,
-          previousSessionCount: 10,
-          points: points,
-          previousPoints: pointsBefore
+          numberOfSessions: 8,
+          previousNumberOfSessions: 10,
+          sessionPoints: points,
+          previousSessionPoints: pointsBefore
       );
 
       final sut = SessionsChartRowViewModel.create(sessionState, []);
@@ -94,10 +94,10 @@ void main() {
 
       final sessionState = SessionState(
           projectId: 'fixture-projectId',
-          sessionCount: 10,
-          previousSessionCount: 5,
-          points: points,
-          previousPoints: pointsBefore
+          numberOfSessions: 10,
+          previousNumberOfSessions: 5,
+          sessionPoints: points,
+          previousSessionPoints: pointsBefore
       );
 
       final parentPoints = [
@@ -114,10 +114,10 @@ void main() {
     test('fallback no points', () {
       final sessionState = SessionState(
           projectId: 'fixture-projectId',
-          sessionCount: 0,
-          previousSessionCount: 0,
-          points: [],
-          previousPoints: []
+          numberOfSessions: 0,
+          previousNumberOfSessions: 0,
+          sessionPoints: [],
+          previousSessionPoints: []
       );
 
       final sut = SessionsChartRowViewModel.create(sessionState, []);

--- a/test/screens/release_health/sessions_chart_row_view_model_test.dart
+++ b/test/screens/release_health/sessions_chart_row_view_model_test.dart
@@ -25,7 +25,7 @@ void main() {
           previousSessionPoints: pointsBefore
       );
 
-      final sut = SessionsChartRowViewModel.create(sessionState, []);
+      final sut = SessionsChartRowViewModel.create(sessionState);
       expect(sut.data.points,
         equals([LineChartPoint(0, 0), LineChartPoint(1, 10)])
       );
@@ -50,7 +50,7 @@ void main() {
           previousSessionPoints: pointsBefore
       );
 
-      final sut = SessionsChartRowViewModel.create(sessionState, []);
+      final sut = SessionsChartRowViewModel.create(sessionState);
       expect(sut.percentChange,
           equals(100.0)
       );
@@ -75,39 +75,9 @@ void main() {
           previousSessionPoints: pointsBefore
       );
 
-      final sut = SessionsChartRowViewModel.create(sessionState, []);
+      final sut = SessionsChartRowViewModel.create(sessionState);
       expect(sut.percentChange,
           equals(-20.0)
-      );
-    });
-
-    test('parentPoints yMax value', () {
-      final pointsBefore = [
-        LineChartPoint(0, 0),
-        LineChartPoint(1, 5),
-      ];
-
-      final points = [
-        LineChartPoint(0, 0),
-        LineChartPoint(1, 10),
-      ];
-
-      final sessionState = SessionState(
-          projectId: 'fixture-projectId',
-          numberOfSessions: 10,
-          previousNumberOfSessions: 5,
-          sessionPoints: points,
-          previousSessionPoints: pointsBefore
-      );
-
-      final parentPoints = [
-        LineChartPoint(0, 0),
-        LineChartPoint(1, 1000)
-      ];
-
-      final sut = SessionsChartRowViewModel.create(sessionState, parentPoints);
-      expect(sut.data.maxY,
-          equals(1000)
       );
     });
 
@@ -120,7 +90,7 @@ void main() {
           previousSessionPoints: []
       );
 
-      final sut = SessionsChartRowViewModel.create(sessionState, []);
+      final sut = SessionsChartRowViewModel.create(sessionState);
       expect(sut.data.points,
           equals([LineChartPoint(0, 0), LineChartPoint(1, 0)])
       );


### PR DESCRIPTION
# Overview

- Show Healthy, Errored, Abnormal, and Crashed session charts in main screen.
- Use 24 hour window for data instead of 12h.
- Show app version in settings and present debug screen on long press.

Relates to #101

# Assets

<img width="711" alt="Bildschirmfoto 2021-02-08 um 11 06 13" src="https://user-images.githubusercontent.com/3984453/107205284-00be1900-69fe-11eb-990c-ee84a4170ae6.png">
