### PR TITLE
feat(sessions): Statistics Updates

### DIFF
--- a/lib/api/sentry_api.dart
+++ b/lib/api/sentry_api.dart
@@ -128,17 +128,18 @@ class SentryApi {
   Future<Sessions> sessions({
     @required String organizationSlug,
     @required String projectId,
-    @required String field,
+    @required Iterable<String> fields,
     String statsPeriod = '24h',
     String interval = '1h',
     String groupBy,
     String statsPeriodStart,
     String statsPeriodEnd}) async {
-    final queryParameters = <String, String>{
+    final queryParameters = <String, dynamic>{ /*String|Iterable<String>*/
       'project': projectId,
       'interval': interval,
-      'field': field
+      'field': fields
     };
+
     if (groupBy != null) {
       queryParameters['groupBy'] = groupBy;
     }
@@ -148,7 +149,11 @@ class SentryApi {
     } else {
       queryParameters['statsPeriod'] = statsPeriod;
     }
-    final response = await client.get(Uri.https(baseUrlName, '$baseUrlPath/organizations/$organizationSlug/sessions/', queryParameters),
+
+    final request = Uri.https(baseUrlName, '$baseUrlPath/organizations/$organizationSlug/sessions/')
+        .resolveUri(Uri(queryParameters: queryParameters));
+
+    final response = await client.get(request,
         headers: _defaultHeader()
     );
     return _parseResponse(response, (jsonMap) => Sessions.fromJson(jsonMap)).asFuture;

--- a/lib/redux/middlewares.dart
+++ b/lib/redux/middlewares.dart
@@ -130,14 +130,14 @@ class SentryApiMiddleware extends MiddlewareClass<AppState> {
           final sessions = await api.sessions(
             organizationSlug: action.organizationSlug,
             projectId: action.projectId,
-            field: SessionGroup.sumSessionKey,
+            fields: [SessionGroup.sumSessionKey, SessionGroup.countUniqueUsersKey],
             groupBy: SessionGroupBy.sessionStatusKey
           );
 
           final sessionsBefore = await api.sessions(
             organizationSlug: action.organizationSlug,
             projectId: action.projectId,
-            field: SessionGroup.sumSessionKey,
+            fields: [SessionGroup.sumSessionKey, SessionGroup.countUniqueUsersKey],
             groupBy: SessionGroupBy.sessionStatusKey,
             statsPeriodStart: '48h',
             statsPeriodEnd: '24h'

--- a/lib/redux/reducers.dart
+++ b/lib/redux/reducers.dart
@@ -146,20 +146,28 @@ GlobalState _fetchSessionsSuccessAction(GlobalState state, FetchSessionsSuccessA
   final sessionsByProjectId = state.sessionsByProjectId;
   sessionsByProjectId[action.projectId] = action.sessions;
 
-  final stabilityScoreByProjectId = state.stabilityScoreByProjectId;
-  stabilityScoreByProjectId[action.projectId] = action.sessions.stabilityScore();
-
   final sessionsBeforeByProjectId = state.sessionsBeforeByProjectId;
   sessionsBeforeByProjectId[action.projectId] = action.sessionsBefore;
+  
+  final crashFreeSessionsByProjectId = state.crashFreeSessionsByProjectId;
+  crashFreeSessionsByProjectId[action.projectId] = action.sessions.crashFreeSessions();
+  
+  final crashFreeSessionsBeforeByProjectId = state.crashFreeSessionsBeforeByProjectId;
+  crashFreeSessionsBeforeByProjectId[action.projectId] = action.sessionsBefore.crashFreeSessions();
 
-  final stabilityScoreBeforeByProjectId = state.stabilityScoreBeforeByProjectId;
-  stabilityScoreBeforeByProjectId[action.projectId] = action.sessionsBefore.stabilityScore();
+  final crashFreeUsersByProjectId = state.crashFreeUsersByProjectId;
+  crashFreeUsersByProjectId[action.projectId] = action.sessions.crashFreeUsers();
 
+  final crashFreeUsersBeforeByProjectId = state.crashFreeUsersBeforeByProjectId;
+  crashFreeUsersBeforeByProjectId[action.projectId] = action.sessionsBefore.crashFreeUsers();
+  
   return state.copyWith(
       sessionsByProjectId: sessionsByProjectId,
-      stabilityScoreByProjectId: stabilityScoreByProjectId,
       sessionsBeforeByProjectId: sessionsBeforeByProjectId,
-      stabilityScoreBeforeByProjectId: stabilityScoreBeforeByProjectId
+      crashFreeSessionsByProjectId: crashFreeSessionsByProjectId,
+      crashFreeSessionsBeforeByProjectId: crashFreeSessionsBeforeByProjectId,
+      crashFreeUsersByProjectId: crashFreeUsersByProjectId,
+      crashFreeUsersBeforeByProjectId: crashFreeUsersBeforeByProjectId
   );
 }
 

--- a/lib/redux/state/app_state.dart
+++ b/lib/redux/state/app_state.dart
@@ -44,8 +44,10 @@ class GlobalState {
       this.releasesLoading,
       this.sessionsByProjectId,
       this.sessionsBeforeByProjectId,
-      this.stabilityScoreByProjectId,
-      this.stabilityScoreBeforeByProjectId,
+      this.crashFreeSessionsByProjectId,
+      this.crashFreeSessionsBeforeByProjectId,
+      this.crashFreeUsersByProjectId,
+      this.crashFreeUsersBeforeByProjectId,
       this.apdexByProjectId,
       this.apdexBeforeByProjectId,
       this.issuesByProjectSlug,
@@ -70,8 +72,10 @@ class GlobalState {
       sessionsByProjectId: {},
       sessionsBeforeByProjectId: {},
       issuesByProjectSlug: {},
-      stabilityScoreByProjectId: {},
-      stabilityScoreBeforeByProjectId: {},
+      crashFreeSessionsByProjectId: {},
+      crashFreeSessionsBeforeByProjectId: {},
+      crashFreeUsersByProjectId: {},
+      crashFreeUsersBeforeByProjectId: {},
       apdexByProjectId: {},
       apdexBeforeByProjectId: {},
       selectedOrganization: null,
@@ -97,8 +101,10 @@ class GlobalState {
 
   final Map<String, Sessions> sessionsByProjectId;
   final Map<String, Sessions> sessionsBeforeByProjectId; // Interval before sessionsByProjectId
-  final Map<String, double> stabilityScoreByProjectId;
-  final Map<String, double> stabilityScoreBeforeByProjectId; // Interval before stabilityScoreByProjectId
+  final Map<String, double> crashFreeSessionsByProjectId;
+  final Map<String, double> crashFreeSessionsBeforeByProjectId; // Interval before stabilityScoreByProjectId
+  final Map<String, double> crashFreeUsersByProjectId;
+  final Map<String, double> crashFreeUsersBeforeByProjectId; // Interval before stabilityScoreByProjectId
   final Map<String, double> apdexByProjectId;
   final Map<String, double> apdexBeforeByProjectId; // Interval before apdexByProjectId
 
@@ -125,8 +131,10 @@ class GlobalState {
     bool releasesLoading,
     Map<String, Sessions> sessionsByProjectId,
     Map<String, Sessions> sessionsBeforeByProjectId,
-    Map<String, double> stabilityScoreByProjectId,
-    Map<String, double> stabilityScoreBeforeByProjectId,
+    Map<String, double> crashFreeSessionsByProjectId,
+    Map<String, double> crashFreeSessionsBeforeByProjectId,
+    Map<String, double> crashFreeUsersByProjectId,
+    Map<String, double> crashFreeUsersBeforeByProjectId,
     Map<String, double> apdexByProjectId,
     Map<String, double> apdexBeforeByProjectId,
     Map<String, List<Group>> issuesByProjectSlug,
@@ -149,8 +157,10 @@ class GlobalState {
       releasesLoading: releasesLoading ?? this.releasesLoading,
       sessionsByProjectId: sessionsByProjectId ?? this.sessionsByProjectId,
       sessionsBeforeByProjectId: sessionsBeforeByProjectId ?? this.sessionsBeforeByProjectId,
-      stabilityScoreByProjectId: stabilityScoreByProjectId ?? this.stabilityScoreByProjectId,
-      stabilityScoreBeforeByProjectId: stabilityScoreBeforeByProjectId ?? this.stabilityScoreBeforeByProjectId,
+      crashFreeSessionsByProjectId: crashFreeSessionsByProjectId ?? this.crashFreeSessionsByProjectId,
+      crashFreeSessionsBeforeByProjectId: crashFreeSessionsBeforeByProjectId ?? this.crashFreeSessionsBeforeByProjectId,
+      crashFreeUsersByProjectId: crashFreeUsersByProjectId ?? this.crashFreeUsersByProjectId,
+      crashFreeUsersBeforeByProjectId: crashFreeUsersBeforeByProjectId ?? this.crashFreeUsersBeforeByProjectId,
       apdexByProjectId: apdexByProjectId ?? this.apdexByProjectId,
       apdexBeforeByProjectId: apdexBeforeByProjectId ?? this.apdexBeforeByProjectId,
       issuesByProjectSlug: issuesByProjectSlug ?? this.issuesByProjectSlug,

--- a/lib/screens/health/health_card.dart
+++ b/lib/screens/health/health_card.dart
@@ -29,7 +29,7 @@ class HealthCard extends StatelessWidget {
                   style: TextStyle(
                     color: viewModel.color,
                     fontWeight: FontWeight.w500,
-                    fontSize: 22,
+                    fontSize: 17,
                   ),
                 ),
               ),
@@ -40,7 +40,7 @@ class HealthCard extends StatelessWidget {
                     style: TextStyle(
                       color: SentryColors.revolver,
                       fontWeight: FontWeight.w500,
-                      fontSize: 17,
+                      fontSize: 14,
                     ),
                   )),
               Padding(
@@ -53,7 +53,7 @@ class HealthCard extends StatelessWidget {
                           viewModel.change,
                           style: TextStyle(
                             color: SentryColors.mamba,
-                            fontSize: 16,
+                            fontSize: 13,
                           ),
                         ),
                         Padding(

--- a/lib/screens/health/health_card_view_model.dart
+++ b/lib/screens/health/health_card_view_model.dart
@@ -16,7 +16,7 @@ class HealthCardViewModel {
       this.value = '--';
     }
     if (value != null && valueBefore != null && value != valueBefore) {
-      final changeValue = 99.9 - 100;//value - valueBefore;
+      final changeValue = value - valueBefore;
       change = changeValue.formattedPercentChange();
       trendIcon = getTrendIcon(changeValue);
     } else {

--- a/lib/screens/health/health_card_view_model.dart
+++ b/lib/screens/health/health_card_view_model.dart
@@ -8,7 +8,23 @@ import 'package:sentry_mobile/utils/crash_free_formatting.dart';
 class HealthCardViewModel {
   HealthCardViewModel(this.value, this.change);
 
-  HealthCardViewModel.stabilityScore(double value, double valueBefore) {
+  HealthCardViewModel.crashFreeSessions(double value, double valueBefore) {
+    color = colorForValue(value);
+    if (value != null) {
+      this.value = value.formattedPercent();
+    } else {
+      this.value = '--';
+    }
+    if (value != null && valueBefore != null && value != valueBefore) {
+      final changeValue = value - valueBefore;
+      change = changeValue.formattedPercentChange();
+      trendIcon = getTrendIcon(changeValue);
+    } else {
+      change = '--';
+    }
+  }
+
+  HealthCardViewModel.crashFreeUsers(double value, double valueBefore) {
     color = colorForValue(value);
     if (value != null) {
       this.value = value.formattedPercent();

--- a/lib/screens/health/health_card_view_model.dart
+++ b/lib/screens/health/health_card_view_model.dart
@@ -16,9 +16,8 @@ class HealthCardViewModel {
       this.value = '--';
     }
     if (value != null && valueBefore != null && value != valueBefore) {
-      final changeValue = value - valueBefore;
-      final trendSign = changeValue > 0 ? '+' : '';
-      change = trendSign + changeValue.formattedPercent();
+      final changeValue = 99.9 - 100;//value - valueBefore;
+      change = changeValue.formattedPercentChange();
       trendIcon = getTrendIcon(changeValue);
     } else {
       change = '--';

--- a/lib/screens/health/health_screen.dart
+++ b/lib/screens/health/health_screen.dart
@@ -150,12 +150,12 @@ class _HealthScreenState extends State<HealthScreen> {
                           Row(
                             children: [
                               HealthCard(
-                                  title: 'Crash Free',
-                                  viewModel: viewModel.stabilityScoreForProject(viewModel.projects[_index]?.project),
+                                title: 'Crash Free Sessions',
+                                viewModel: viewModel.crashFreeSessionsForProject(viewModel.projects[_index]?.project),
                               ),
                               HealthCard(
-                                title: 'Apdex',
-                                viewModel: viewModel.apdexForProject(viewModel.projects[_index]?.project),
+                                title: 'Crash Free Users',
+                                viewModel: viewModel.crashFreeUsersForProject(viewModel.projects[_index]?.project),
                               ),
                             ],
                           )

--- a/lib/screens/health/health_screen.dart
+++ b/lib/screens/health/health_screen.dart
@@ -126,6 +126,7 @@ class _HealthScreenState extends State<HealthScreen> {
                             title: 'Healthy',
                             color: SentryColors.buttercup,
                             sessionState: viewModel.sessionState(_index, SessionStatus.healthy),
+                            flipDeltaColors: true,
                           ),
                           SessionsChartRow(
                             title: 'Errored',

--- a/lib/screens/health/health_screen_view_model.dart
+++ b/lib/screens/health/health_screen_view_model.dart
@@ -17,8 +17,10 @@ class HealthScreenViewModel {
       _erroredSessionsStateByProjectId = store.state.globalState.sessionStateByProjectId({SessionStatus.errored}),
       _abnormalSessionsStateByProjectId = store.state.globalState.sessionStateByProjectId({SessionStatus.abnormal}),
       _crashedSessionStateByProjectId = store.state.globalState.sessionStateByProjectId({SessionStatus.crashed}),
-      _stabilityScoreByProjectId = store.state.globalState.stabilityScoreByProjectId,
-      _stabilityScoreBeforeByProjectId = store.state.globalState.stabilityScoreBeforeByProjectId,
+      _crashFreeSessionsByProjectId = store.state.globalState.crashFreeSessionsByProjectId,
+      _crashFreeSessionsBeforeByProjectId = store.state.globalState.crashFreeSessionsBeforeByProjectId,
+      _crashFreeUsersByProjectId = store.state.globalState.crashFreeUsersByProjectId,
+      _crashFreeUsersBeforeByProjectId = store.state.globalState.crashFreeUsersBeforeByProjectId,
       _apdexByProjectId = store.state.globalState.apdexByProjectId,
       _apdexBeforeByProjectId = store.state.globalState.apdexBeforeByProjectId,
       _fetchProjectsNeeded = !store.state.globalState.projectsFetchedOnce &&
@@ -41,8 +43,10 @@ class HealthScreenViewModel {
   final Map<String, SessionState> _abnormalSessionsStateByProjectId;
   final Map<String, SessionState> _crashedSessionStateByProjectId;
 
-  final Map<String, double> _stabilityScoreByProjectId;
-  final Map<String, double> _stabilityScoreBeforeByProjectId;
+  final Map<String, double> _crashFreeSessionsByProjectId;
+  final Map<String, double> _crashFreeSessionsBeforeByProjectId;
+  final Map<String, double> _crashFreeUsersByProjectId;
+  final Map<String, double> _crashFreeUsersBeforeByProjectId;
 
   final Map<String, double> _apdexByProjectId;
   final Map<String, double> _apdexBeforeByProjectId;
@@ -93,10 +97,17 @@ class HealthScreenViewModel {
     }
   }
 
-  HealthCardViewModel stabilityScoreForProject(Project project) {
-    return HealthCardViewModel.stabilityScore(
-      _stabilityScoreByProjectId[project.id],
-      _stabilityScoreBeforeByProjectId[project.id],
+  HealthCardViewModel crashFreeSessionsForProject(Project project) {
+    return HealthCardViewModel.crashFreeSessions(
+      _crashFreeSessionsByProjectId[project.id],
+      _crashFreeSessionsBeforeByProjectId[project.id],
+    );
+  }
+
+  HealthCardViewModel crashFreeUsersForProject(Project project) {
+    return HealthCardViewModel.crashFreeSessions(
+      _crashFreeUsersByProjectId[project.id],
+      _crashFreeUsersBeforeByProjectId[project.id],
     );
   }
 

--- a/lib/screens/health/sessions_chart_row.dart
+++ b/lib/screens/health/sessions_chart_row.dart
@@ -7,11 +7,12 @@ import '../../utils/sentry_colors.dart';
 import '../../utils/sentry_icons.dart';
 
 class SessionsChartRow extends StatelessWidget {
-  SessionsChartRow({@required this.title, @required this.color, @required this.sessionState});
+  SessionsChartRow({@required this.title, @required this.color, @required this.sessionState, this.flipDeltaColors = false});
 
   final String title;
   final Color color;
   final SessionState sessionState;
+  final bool flipDeltaColors;
 
   @override
   Widget build(BuildContext context) {
@@ -96,7 +97,7 @@ class SessionsChartRow extends StatelessWidget {
                     )),
                   Padding(
                     padding: EdgeInsets.only(left: viewModel.percentChange == 0.0 ? 0 : 7),
-                    child: _getTrendIcon(viewModel.percentChange),
+                    child: _getTrendIcon(viewModel.percentChange, flipDeltaColors),
                   )
                 ]
               )
@@ -115,12 +116,19 @@ class SessionsChartRow extends StatelessWidget {
     return change == 0 ? '--' : _getTrendSign(change) + change.floor().toString() + '%';
   }
 
-  Icon _getTrendIcon(double change) {
+  Color _getTrendColor(double change, bool flipDelta) {
+    return change > 0
+        ? !flipDelta ? Color(0xffEE6855) : Color(0xff23B480)
+        : !flipDelta ? Color(0xff23B480) : Color(0xffEE6855);
+  }
+
+  Icon _getTrendIcon(double change, bool flipDeltaColor) {
     if (change == 0) {
       return null;
     }
+    final trendColor = _getTrendColor(change, flipDeltaColor);
     return change > 0
-        ? Icon(SentryIcons.trend_up, color: Color(0xffEE6855), size: 8.0)
-        : Icon(SentryIcons.trend_down, color: Color(0xff23B480), size: 8.0);
+        ? Icon(SentryIcons.trend_up, color: trendColor, size: 8.0)
+        : Icon(SentryIcons.trend_down, color: trendColor, size: 8.0);
   }
 }

--- a/lib/types/session_group.dart
+++ b/lib/types/session_group.dart
@@ -13,6 +13,7 @@ class SessionGroup {
   factory SessionGroup.fromJson(Map<String, dynamic> json) => _$SessionGroupFromJson(json);
 
   static const sumSessionKey = 'sum(session)';
+  static const countUniqueUsersKey = 'count_unique(user)';
 
   final SessionGroupBy by;
   final SessionGroupTotals totals;

--- a/lib/types/session_group_series.dart
+++ b/lib/types/session_group_series.dart
@@ -7,11 +7,14 @@ part 'session_group_series.g.dart';
 
 @JsonSerializable()
 class SessionGroupSeries {
-  SessionGroupSeries(this.sumSession);
+  SessionGroupSeries(this.sumSession, this.countUniqueUsers);
   factory SessionGroupSeries.fromJson(Map<String, dynamic> json) => _$SessionGroupSeriesFromJson(json);
 
   @JsonKey(name: SessionGroup.sumSessionKey)
   final List<int> sumSession;
+
+  @JsonKey(name: SessionGroup.countUniqueUsersKey)
+  final List<int> countUniqueUsers;
 
   Map<String, dynamic> toJson() => _$SessionGroupSeriesToJson(this);
 }

--- a/lib/types/session_group_series.g.dart
+++ b/lib/types/session_group_series.g.dart
@@ -9,10 +9,12 @@ part of 'session_group_series.dart';
 SessionGroupSeries _$SessionGroupSeriesFromJson(Map<String, dynamic> json) {
   return SessionGroupSeries(
     (json['sum(session)'] as List)?.map((e) => e as int)?.toList(),
+    (json['count_unique(user)'] as List)?.map((e) => e as int)?.toList(),
   );
 }
 
 Map<String, dynamic> _$SessionGroupSeriesToJson(SessionGroupSeries instance) =>
     <String, dynamic>{
       'sum(session)': instance.sumSession,
+      'count_unique(user)': instance.countUniqueUsers,
     };

--- a/lib/types/session_group_totals.dart
+++ b/lib/types/session_group_totals.dart
@@ -7,11 +7,14 @@ part 'session_group_totals.g.dart';
 
 @JsonSerializable()
 class SessionGroupTotals {
-  SessionGroupTotals(this.sumSession);
+  SessionGroupTotals(this.sumSession, this.countUniqueUsers);
   factory SessionGroupTotals.fromJson(Map<String, dynamic> json) => _$SessionGroupTotalsFromJson(json);
 
   @JsonKey(name: SessionGroup.sumSessionKey)
   final int sumSession;
+
+  @JsonKey(name: SessionGroup.countUniqueUsersKey)
+  final int countUniqueUsers;
 
   Map<String, dynamic> toJson() => _$SessionGroupTotalsToJson(this);
 }

--- a/lib/types/session_group_totals.g.dart
+++ b/lib/types/session_group_totals.g.dart
@@ -9,10 +9,12 @@ part of 'session_group_totals.dart';
 SessionGroupTotals _$SessionGroupTotalsFromJson(Map<String, dynamic> json) {
   return SessionGroupTotals(
     json['sum(session)'] as int,
+    json['count_unique(user)'] as int,
   );
 }
 
 Map<String, dynamic> _$SessionGroupTotalsToJson(SessionGroupTotals instance) =>
     <String, dynamic>{
       'sum(session)': instance.sumSession,
+      'count_unique(user)': instance.countUniqueUsers,
     };

--- a/lib/utils/crash_free_formatting.dart
+++ b/lib/utils/crash_free_formatting.dart
@@ -3,17 +3,29 @@ import 'package:intl/intl.dart';
 
 extension CrashFreeFormatting on double {
 
-  static final belowThresholdFormatter = NumberFormat('###');
-  static final aboveThresholdFormatter = NumberFormat('###.###');
+  static final noDecimalPointFormatter = NumberFormat('###');
+  static final decimalFormatter = NumberFormat('###.###');
 
   // The double value is expected to be between 0 and 100
   String formattedPercent({double threshold = 98.0}) {
     if (this > 0.0 && this < 1.0) {
       return '<1%';
     } else if (this <= threshold) {
-      return belowThresholdFormatter.format(this) + '%';
+      return noDecimalPointFormatter.format(this) + '%';
     } else {
-      return aboveThresholdFormatter.format(this) + '%';
+      return decimalFormatter.format(this) + '%';
+    }
+  }
+
+  // Value expected to be absolute percent values: 100% -> 100
+  String formattedPercentChange({double threshold = 1.0}) {
+    final absoluteValue = abs();
+    final prefix = this > 0 ? '+' : '';
+
+    if (absoluteValue > 0.0 && absoluteValue < threshold) {
+      return prefix + decimalFormatter.format(this) + '%';
+    } else {
+      return prefix + noDecimalPointFormatter.format(this) + '%';
     }
   }
 }

--- a/lib/utils/crash_free_formatting.dart
+++ b/lib/utils/crash_free_formatting.dart
@@ -19,13 +19,7 @@ extension CrashFreeFormatting on double {
 
   // Value expected to be absolute percent values: 100% -> 100
   String formattedPercentChange({double threshold = 1.0}) {
-    final absoluteValue = abs();
     final prefix = this > 0 ? '+' : '';
-
-    if (absoluteValue > 0.0 && absoluteValue < threshold) {
-      return prefix + decimalFormatter.format(this) + '%';
-    } else {
-      return prefix + noDecimalPointFormatter.format(this) + '%';
-    }
+    return prefix + decimalFormatter.format(this) + '%';
   }
 }

--- a/lib/utils/stability_score.dart
+++ b/lib/utils/stability_score.dart
@@ -2,7 +2,7 @@ import '../types/session_status.dart';
 import '../types/sessions.dart';
 
 extension StabilityScore on Sessions {
-  double stabilityScore() {
+  double crashFreeSessions() {
     int healthy;
     int errored;
     int abnormal;
@@ -28,4 +28,34 @@ extension StabilityScore on Sessions {
       return 100 - (crashed / sum) * 100;
     }
   }
+
+  // TODO(denis): DRY
+  double crashFreeUsers() {
+    int healthy;
+    int errored;
+    int abnormal;
+    int crashed;
+    for (final group in groups) {
+      if (group?.by?.sessionStatus == SessionStatus.healthy) {
+        healthy = group?.totals?.countUniqueUsers;
+      } else if (group?.by?.sessionStatus == SessionStatus.errored) {
+        errored = group?.totals?.countUniqueUsers;
+      } else if (group?.by?.sessionStatus == SessionStatus.abnormal) {
+        abnormal = group?.totals?.countUniqueUsers;
+      } else if (group?.by?.sessionStatus == SessionStatus.crashed) {
+        crashed = group?.totals?.countUniqueUsers;
+      }
+    }
+    if (healthy == null || errored == null || abnormal == null || crashed == null) {
+      return null;
+    }
+    final sum = healthy + abnormal + crashed + errored;
+    if (sum == 0) {
+      return null;
+    } else {
+      return 100 - (crashed / sum) * 100;
+    }
+  }
+  
+  
 }

--- a/test/util/crash_free_formatting_tests.dart
+++ b/test/util/crash_free_formatting_tests.dart
@@ -44,32 +44,20 @@ void main() {
   });
 
   group('formattedPercentChange', () {
-    test('>0 && <1', () {
+    test('positive', () {
       expect(0.9.formattedPercentChange(), equals('+0.9%'));
       expect(0.99.formattedPercentChange(), equals('+0.99%'));
       expect(0.999.formattedPercentChange(), equals('+0.999%'));
       expect(0.001.formattedPercentChange(), equals('+0.001%'));
+      expect(97.1.formattedPercentChange(), equals('+97.1%'));
     });
 
-    test('>-1 && <0', () {
+    test('negative', () {
       expect((-0.9).formattedPercentChange(), equals('-0.9%'));
       expect((-0.99).formattedPercentChange(), equals('-0.99%'));
       expect((-0.999).formattedPercentChange(), equals('-0.999%'));
       expect((-0.001).formattedPercentChange(), equals('-0.001%'));
-    });
-
-    test('rounded', () {
-      expect(97.1.formattedPercentChange(), equals('+97%'));
-      expect(97.9.formattedPercentChange(), equals('+98%'));
-      expect(98.12.formattedPercentChange(), equals('+98%'));
-      expect(400.12.formattedPercentChange(), equals('+400%'));
-      expect(10000.12.formattedPercentChange(), equals('+10000%'));
-
-      expect((-97.1).formattedPercentChange(), equals('-97%'));
-      expect((-97.9).formattedPercentChange(), equals('-98%'));
-      expect((-98.12).formattedPercentChange(), equals('-98%'));
-      expect((-400.12).formattedPercentChange(), equals('-400%'));
-      expect((-10000.12).formattedPercentChange(), equals('-10000%'));
+      expect((-97.1).formattedPercentChange(), equals('-97.1%'));
     });
   });
 }

--- a/test/util/crash_free_formatting_tests.dart
+++ b/test/util/crash_free_formatting_tests.dart
@@ -3,7 +3,7 @@ import 'package:test/test.dart';
 import 'package:sentry_mobile/utils/crash_free_formatting.dart';
 
 void main() {
-  group('crash free formatting', () {
+  group('formattedPercent', () {
     test('0', () {
       expect(0.0.formattedPercent(), equals('0%'));
     });
@@ -21,7 +21,6 @@ void main() {
     test('threshold 98', () {
       expect(98.0.formattedPercent(), equals('98%'));
     });
-
 
     test('above threshold 98 one decimal point', () {
       expect(98.1.formattedPercent(), equals('98.1%'));
@@ -41,6 +40,36 @@ void main() {
 
     test('above threshold 100', () {
       expect(100.0.formattedPercent(), equals('100%'));
+    });
+  });
+
+  group('formattedPercentChange', () {
+    test('>0 && <1', () {
+      expect(0.9.formattedPercentChange(), equals('+0.9%'));
+      expect(0.99.formattedPercentChange(), equals('+0.99%'));
+      expect(0.999.formattedPercentChange(), equals('+0.999%'));
+      expect(0.001.formattedPercentChange(), equals('+0.001%'));
+    });
+
+    test('>-1 && <0', () {
+      expect((-0.9).formattedPercentChange(), equals('-0.9%'));
+      expect((-0.99).formattedPercentChange(), equals('-0.99%'));
+      expect((-0.999).formattedPercentChange(), equals('-0.999%'));
+      expect((-0.001).formattedPercentChange(), equals('-0.001%'));
+    });
+
+    test('rounded', () {
+      expect(97.1.formattedPercentChange(), equals('+97%'));
+      expect(97.9.formattedPercentChange(), equals('+98%'));
+      expect(98.12.formattedPercentChange(), equals('+98%'));
+      expect(400.12.formattedPercentChange(), equals('+400%'));
+      expect(10000.12.formattedPercentChange(), equals('+10000%'));
+
+      expect((-97.1).formattedPercentChange(), equals('-97%'));
+      expect((-97.9).formattedPercentChange(), equals('-98%'));
+      expect((-98.12).formattedPercentChange(), equals('-98%'));
+      expect((-400.12).formattedPercentChange(), equals('-400%'));
+      expect((-10000.12).formattedPercentChange(), equals('-10000%'));
     });
   });
 }

--- a/test/util/stability_score_tests.dart
+++ b/test/util/stability_score_tests.dart
@@ -54,7 +54,7 @@ void main() {
 SessionGroup _givenSessionGroup(SessionStatus status, int num) {
   return SessionGroup(
       SessionGroupBy(status),
-      SessionGroupTotals(num),
-      SessionGroupSeries([])
+      SessionGroupTotals(num, num),
+      SessionGroupSeries([], [])
   );
 }

--- a/test/util/stability_score_tests.dart
+++ b/test/util/stability_score_tests.dart
@@ -16,16 +16,16 @@ void main() {
       final crashed = _givenSessionGroup(SessionStatus.crashed, 1);
 
       var sessions = Sessions([], [healthy]);
-      expect(sessions.stabilityScore(), isNull);
+      expect(sessions.crashFreeSessions(), isNull);
 
       sessions = Sessions([], [healthy, errored]);
-      expect(sessions.stabilityScore(), isNull);
+      expect(sessions.crashFreeSessions(), isNull);
 
       sessions = Sessions([], [healthy, errored, abnormal]);
-      expect(sessions.stabilityScore(), isNull);
+      expect(sessions.crashFreeSessions(), isNull);
 
       sessions = Sessions([], [errored, abnormal, crashed]);
-      expect(sessions.stabilityScore(), isNull);
+      expect(sessions.crashFreeSessions(), isNull);
     });
 
     test('stability score', () {
@@ -35,7 +35,7 @@ void main() {
       final crashed = _givenSessionGroup(SessionStatus.crashed, 1);
 
       final sessions = Sessions([], [healthy, errored, abnormal, crashed]);
-      expect(sessions.stabilityScore(), equals(75.0));
+      expect(sessions.crashFreeSessions(), equals(75.0));
     });
 
     test('all zero equals null', () {
@@ -45,7 +45,7 @@ void main() {
       final crashed = _givenSessionGroup(SessionStatus.crashed, 0);
 
       final sessions = Sessions([], [healthy, errored, abnormal, crashed]);
-      expect(sessions.stabilityScore(), isNull);
+      expect(sessions.crashFreeSessions(), isNull);
     });
 
   });


### PR DESCRIPTION
# Whats new?

- Crashfree: if the change is exactly 0 we shouldn't show the number with an arrow
- Hide Apdex
- Show Crash Free Sessions
- Show Crash Free Users
- Use text sizes from design again as we now have more data on screen
- Healthy session have a positive delta value

Relates to #101

# Assets

<img width="712" alt="Bildschirmfoto 2021-02-09 um 13 41 51" src="https://user-images.githubusercontent.com/3984453/107365063-9334ea00-6adc-11eb-9aa8-6bc5f75ed2f3.png">
