### PR TITLE
ehna(sessions): Minor interface updates

### DIFF
--- a/lib/screens/health/health_screen.dart
+++ b/lib/screens/health/health_screen.dart
@@ -117,7 +117,7 @@ class _HealthScreenState extends State<HealthScreen> {
                       child: Column(
                         children: [
                           Padding(
-                            padding: const EdgeInsets.only(bottom: 22.0),
+                            padding: const EdgeInsets.only(bottom: 16.0),
                             child: Row(
                               mainAxisAlignment: MainAxisAlignment.spaceBetween,
                               children: [

--- a/lib/screens/health/health_screen.dart
+++ b/lib/screens/health/health_screen.dart
@@ -96,24 +96,24 @@ class _HealthScreenState extends State<HealthScreen> {
                 child: Column(
                   children: [
                     Padding(
-                      padding: EdgeInsets.only(left: 16, right: 16),
+                      padding: EdgeInsets.only(left: 22, right: 22),
                       child: HealthDivider(
                         onSeeAll: () {},
                         title: 'in the last 24 hours',
                       ),
                     ),
                     SizedBox(
-                        height: 200,
+                        height: 208,
                         child: PageView.builder(
                           itemCount: viewModel.projects.length,
-                          controller: PageController(viewportFraction: (MediaQuery.of(context).size.width - 44) / MediaQuery.of(context).size.width),
+                          controller: PageController(viewportFraction: (MediaQuery.of(context).size.width - 32) / MediaQuery.of(context).size.width),
                           onPageChanged: (int index) => setState(() => updateIndex(index)),
                           itemBuilder: (context, index) {
                             return viewModel.projectCard(index);
                           },
                         )),
                     Container(
-                      padding: EdgeInsets.only(top: 22, left: 22, right: 22),
+                      padding: EdgeInsets.only(top: 16, left: 22, right: 22),
                       child: Column(
                         children: [
                           Padding(

--- a/lib/screens/health/project_card.dart
+++ b/lib/screens/health/project_card.dart
@@ -65,7 +65,7 @@ class ProjectCard extends StatelessWidget {
     }
 
     return Card(
-        margin: const EdgeInsets.only(top: 8, bottom: 8, left: 0, right: 16),
+        margin: const EdgeInsets.only(top: 8, bottom: 8, left: 6, right: 6),
         elevation: 4,
         shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.all(Radius.circular(16))),

--- a/lib/screens/health/sessions_chart_row.dart
+++ b/lib/screens/health/sessions_chart_row.dart
@@ -20,84 +20,101 @@ class SessionsChartRow extends StatelessWidget {
     final viewModel = SessionsChartRowViewModel.create(sessionState);
     
     return Container(
-        padding: EdgeInsets.only(bottom: 22),
-        margin: EdgeInsets.only(bottom: 22),
-        decoration: BoxDecoration(
-          border:
-          Border(bottom: BorderSide(width: 1, color: Color(0x33B9C1D9))),
-        ),
-        child:
-        Row(mainAxisAlignment: MainAxisAlignment.spaceBetween, children: [
-          Padding(
-            padding: EdgeInsets.only(bottom: 5),
-            child: Text(title,
-              style: TextStyle(
-                color: SentryColors.revolver,
-                fontWeight: FontWeight.w600,
-                fontSize: 16,
-              )
-            )
-          ),
-          Expanded(
-              child:
-                viewModel.data == null
-                ? Container(
-                  margin: EdgeInsets.symmetric(horizontal: 20),
-                  child: Column(
-                      mainAxisSize: MainAxisSize.max,
-                      mainAxisAlignment: MainAxisAlignment.end,
-                      children: [
-                        LinearProgressIndicator(
-                            minHeight: 2.0,
-                            backgroundColor: Colors.white,
-                            valueColor: AlwaysStoppedAnimation<Color>(color)
-                        )
-                      ]
-                  ),
-                  height: 35,
+      padding: EdgeInsets.only(bottom: 22),
+      margin: EdgeInsets.only(bottom: 22),
+      decoration: BoxDecoration(
+        border:
+        Border(bottom: BorderSide(width: 1, color: Color(0x33B9C1D9))),
+      ),
+      child: Container(
+        height: 38,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Container(
+              width: 72,
+              child: Padding(
+                padding: EdgeInsets.only(bottom: 5),
+                child: Text(title,
+                  style: TextStyle(
+                    color: SentryColors.revolver,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 16,
+                  )
                 )
-                : Container(
-                  margin: EdgeInsets.symmetric(horizontal: 20),
-                  child: LineChart(
-                      data: viewModel.data,
-                      lineWidth: 2.0,
-                      lineColor: color,
-                      gradientStart: color.withAlpha(84),
-                      gradientEnd: color.withAlpha(28),
-                      cubicLines: false
-                  ),
-                  height: 35,
-                )
-          ),
-          Column(
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              Padding(
-                  padding: EdgeInsets.only(bottom: 5),
-                  child: Text(viewModel.numberOfIssues.formattedNumberOfSession(),
+              ),
+            ),
+            Expanded(
+                child:
+                  viewModel.data == null
+                  ? Container(
+                    margin: EdgeInsets.symmetric(horizontal: 12),
+                    child: Column(
+                        mainAxisSize: MainAxisSize.max,
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          LinearProgressIndicator(
+                              minHeight: 2.0,
+                              backgroundColor: Colors.white,
+                              valueColor: AlwaysStoppedAnimation<Color>(color)
+                          )
+                        ]
+                    ),
+                    height: 35,
+                  )
+                  : Container(
+                    margin: EdgeInsets.symmetric(horizontal: 12),
+                    child: LineChart(
+                        data: viewModel.data,
+                        lineWidth: 2.0,
+                        lineColor: color,
+                        gradientStart: color.withAlpha(84),
+                        gradientEnd: color.withAlpha(28),
+                        cubicLines: false
+                    ),
+                    height: 35,
+                  )
+            ),
+            Container(
+              width: 44,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  Padding(
+                    padding: EdgeInsets.only(bottom: 4),
+                    child: Text(viewModel.numberOfIssues.formattedNumberOfSession(),
                       style: TextStyle(
                         color: SentryColors.woodSmoke,
                         fontWeight: FontWeight.w600,
                         fontSize: 16,
-                      ))),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Padding(
-                    padding: EdgeInsets.only(right: viewModel.percentChange == 0.0 ? 0 : 7),
-                    child: _getTrendIcon(viewModel.percentChange, flipDeltaColors),
-                  ),
-                  Text(_getTrendPercentage(viewModel.percentChange),
-                    style: TextStyle(
-                      color: SentryColors.lavenderGray,
-                      fontSize: 12,
+                      )
                     )
+                  ),
+                  FittedBox(
+                    fit: BoxFit.fitWidth,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: [
+                        Padding(
+                          padding: EdgeInsets.only(right: viewModel.percentChange == 0.0 ? 0 : 7),
+                          child: _getTrendIcon(viewModel.percentChange, flipDeltaColors),
+                        ),
+                        Text(_getTrendPercentage(viewModel.percentChange),
+                          style: TextStyle(
+                            color: SentryColors.lavenderGray,
+                            fontSize: 12,
+                          )
+                        )
+                      ]
+                    ),
                   )
-                ]
-              )
-            ],
-          ),
-        ]));
+                ],
+              ),
+            ),
+          ]
+        ),
+      )
+    );
   }
 
   // Helper


### PR DESCRIPTION
# Whats new?

- Center top project cards
- Fixed width containers to left/right of session charts

Relates to #101 

# Assets 

<img width="750" alt="Bildschirmfoto 2021-02-10 um 18 38 46" src="https://user-images.githubusercontent.com/3984453/107548911-7fb67b80-6bcf-11eb-92fb-841397ccf611.png">
