### PR TITLE
enha(sessions): Only show projects with session data

### DIFF
--- a/lib/api/sentry_api.dart
+++ b/lib/api/sentry_api.dart
@@ -63,7 +63,7 @@ class SentryApi {
     return _parseResponse(response, (jsonMap) => Project.fromJson(jsonMap)).asFuture;
   }
 
-  Future<Set<String>>projectsWithSessions(String organizationSlug) async {
+  Future<Set<String>>projectIdsWithSessions(String organizationSlug) async {
     final queryParameters = <String, dynamic>{ /*String|Iterable<String>*/
       'project': '-1',
       'interval': '90d',

--- a/lib/api/sentry_api.dart
+++ b/lib/api/sentry_api.dart
@@ -5,8 +5,6 @@ import 'package:async/async.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart';
 import 'package:sentry_flutter/sentry_flutter.dart' as sentry;
-import 'package:sentry_mobile/types/session_group.dart';
-import 'package:sentry_mobile/types/session_group_by.dart';
 
 import '../api/api_errors.dart';
 import '../types/cursor.dart';
@@ -14,6 +12,8 @@ import '../types/group.dart';
 import '../types/organization.dart';
 import '../types/project.dart';
 import '../types/release.dart';
+import '../types/session_group.dart';
+import '../types/session_group_by.dart';
 import '../types/sessions.dart';
 import '../types/user.dart';
 import '../utils/date_time_format.dart';

--- a/lib/redux/actions.dart
+++ b/lib/redux/actions.dart
@@ -45,10 +45,11 @@ class FetchOrganizationsAndProjectsAction {
 }
 
 class FetchOrganizationsAndProjectsSuccessAction {
-  FetchOrganizationsAndProjectsSuccessAction(this.organizations, this.projectsByOrganizationSlug, this.projectCursorsByOrganizationSlug, this.reload);
+  FetchOrganizationsAndProjectsSuccessAction(this.organizations, this.projectsByOrganizationSlug, this.projectCursorsByOrganizationSlug, this.projectIdsWithSessions, this.reload);
   final List<Organization> organizations;
   final Map<String, List<Project>> projectsByOrganizationSlug;
   final Map<String, Cursor> projectCursorsByOrganizationSlug;
+  final Set<String> projectIdsWithSessions;
   final bool reload;
 }
 

--- a/lib/redux/middlewares.dart
+++ b/lib/redux/middlewares.dart
@@ -25,7 +25,7 @@ class SentryApiMiddleware extends MiddlewareClass<AppState> {
           final individualOrganizations = <Organization>[];
           final Map<String, Cursor> projectCursorsByOrganizationSlug = {};
           final Map<String, List<Project>> projectsByOrganizationId = {};
-          final Set<String> projectsWithSessions = {};
+          final Set<String> projectIdsWithSessions = {};
 
           for (final organization in organizations) {
             final individualOrganization = await api.organization(organization.slug);
@@ -45,8 +45,8 @@ class SentryApiMiddleware extends MiddlewareClass<AppState> {
               projectsByOrganizationId[organization.slug] = projects;
             }
 
-            final projectsWithSessionsForOrganization = await api.projectsWithSessions(organization.slug);
-            projectsWithSessions.addAll(projectsWithSessionsForOrganization);
+            final projectsWithSessionsForOrganization = await api.projectIdsWithSessions(organization.slug);
+            projectIdsWithSessions.addAll(projectsWithSessionsForOrganization);
 
             if (action.pagination) {
               // Keep cursor if there are less than value projects
@@ -57,7 +57,7 @@ class SentryApiMiddleware extends MiddlewareClass<AppState> {
               }
             }
           }
-          store.dispatch(FetchOrganizationsAndProjectsSuccessAction(individualOrganizations, projectsByOrganizationId, projectCursorsByOrganizationSlug, projectsWithSessions, action.reload));
+          store.dispatch(FetchOrganizationsAndProjectsSuccessAction(individualOrganizations, projectsByOrganizationId, projectCursorsByOrganizationSlug, projectIdsWithSessions, action.reload));
         } catch (e) {
           store.dispatch(FetchOrganizationsAndProjectsFailureAction(e));
         }

--- a/lib/redux/reducers.dart
+++ b/lib/redux/reducers.dart
@@ -69,26 +69,27 @@ GlobalState _fetchOrganizationsAndProjectsSuccessAction(GlobalState state, Fetch
   final projectsById = <String, Project>{};
 
   if (!action.reload) {
-    for (final project in state.projects) {
+    for (final project in state.projectsWithSessions) {
       projectsById[project.id] = project;
     }
   }
 
   for (final organizationSlug in action.projectsByOrganizationSlug.keys) {
     for (final project in action.projectsByOrganizationSlug[organizationSlug]) {
-      if (project.latestRelease != null) {
-        organizationsSlugByProjectSlug[project.slug] = organizationSlug;
+      organizationsSlugByProjectSlug[project.slug] = organizationSlug;
+
+      if (action.projectIdsWithSessions.contains(project.id)) {
         projectsById[project.id] = project;
       }
     }
   }
 
-  final projects = projectsById.values.toList();
+  final projectsWithSessions = projectsById.values.toList();
 
-  projects.sort((Project a, Project b) {
+  projectsWithSessions.sort((Project a, Project b) {
     return (a.slug ?? a.name).toLowerCase().compareTo((b.slug ?? b.name).toLowerCase());
   });
-  projects.sort((Project a, Project b) {
+  projectsWithSessions.sort((Project a, Project b) {
     final valueA = a.isBookmarked ? 0 : 1;
     final valueB = b.isBookmarked ? 0 : 1;
     return valueA.compareTo(valueB);
@@ -99,7 +100,7 @@ GlobalState _fetchOrganizationsAndProjectsSuccessAction(GlobalState state, Fetch
     organizationsSlugByProjectSlug: organizationsSlugByProjectSlug,
     projectCursorsByOrganizationSlug: action.projectCursorsByOrganizationSlug,
     projectsByOrganizationSlug: action.projectsByOrganizationSlug,
-    projects: projects,
+    projectsWithSessions: projectsWithSessions,
     projectsFetchedOnce: true,
   );
 }
@@ -117,16 +118,13 @@ GlobalState _fetchLatestReleasesAction(GlobalState state, FetchLatestReleasesAct
 }
 
 GlobalState _fetchLatestReleasesSuccessAction(GlobalState state, FetchLatestReleasesSuccessAction action) {
-  final projects = <Project>[];
   final latestReleasesByProjectId = <String, Release>{};
 
   for (final projectsWithLatestRelease in action.projectsWithLatestReleases) {
-    projects.add(projectsWithLatestRelease.project);
     latestReleasesByProjectId[projectsWithLatestRelease.project.id] = projectsWithLatestRelease.release;
   }
 
   return state.copyWith(
-    projects: projects,
     latestReleasesByProjectId: latestReleasesByProjectId
   );
 }
@@ -204,7 +202,7 @@ GlobalState _bookmarkProjectSuccessAction(GlobalState state, BookmarkProjectSucc
   final projectsByOrganizationSlug = <String, List<Project>>{};
   final projects = <Project>[];
 
-  for (final project in state.projects) {
+  for (final project in state.projectsWithSessions) {
     if (project.id == action.project.id) {
       projects.add(action.project);
     } else {
@@ -235,7 +233,7 @@ GlobalState _bookmarkProjectSuccessAction(GlobalState state, BookmarkProjectSucc
 
   return state.copyWith(
       projectsByOrganizationSlug: projectsByOrganizationSlug,
-      projects: projects
+      projectsWithSessions: projects
   );
 }
 

--- a/lib/redux/reducers.dart
+++ b/lib/redux/reducers.dart
@@ -100,6 +100,7 @@ GlobalState _fetchOrganizationsAndProjectsSuccessAction(GlobalState state, Fetch
     organizationsSlugByProjectSlug: organizationsSlugByProjectSlug,
     projectCursorsByOrganizationSlug: action.projectCursorsByOrganizationSlug,
     projectsByOrganizationSlug: action.projectsByOrganizationSlug,
+    projectIdsWithSessions: action.projectIdsWithSessions,
     projectsWithSessions: projectsWithSessions,
     projectsFetchedOnce: true,
   );

--- a/lib/redux/state/app_state.dart
+++ b/lib/redux/state/app_state.dart
@@ -39,6 +39,7 @@ class GlobalState {
       this.projectCursorsByOrganizationSlug,
       this.projectsByOrganizationSlug,
       this.projectsFetchedOnce,
+      this.projectIdsWithSessions,
       this.projectsWithSessions,
       this.latestReleasesByProjectId,
       this.sessionsByProjectId,
@@ -65,6 +66,7 @@ class GlobalState {
       projectCursorsByOrganizationSlug: {},
       projectsByOrganizationSlug: {},
       projectsFetchedOnce: false,
+      projectIdsWithSessions: {},
       projectsWithSessions: [],
       latestReleasesByProjectId: {},
       sessionsByProjectId: {},
@@ -93,6 +95,7 @@ class GlobalState {
   final Map<String, List<Project>> projectsByOrganizationSlug;
   final bool projectsFetchedOnce;
 
+  final Set<String> projectIdsWithSessions;
   final List<Project> projectsWithSessions;
   final Map<String, Release> latestReleasesByProjectId;
 
@@ -124,6 +127,7 @@ class GlobalState {
     Map<String, List<Project>> projectsByOrganizationSlug,
     bool projectsFetchedOnce,
     bool projectsLoading,
+    Set<String> projectIdsWithSessions,
     List<Project> projectsWithSessions,
     Map<String, Release> latestReleasesByProjectId,
     Map<String, Sessions> sessionsByProjectId,
@@ -149,6 +153,7 @@ class GlobalState {
       projectCursorsByOrganizationSlug: projectCursorsByOrganizationSlug ?? this.projectCursorsByOrganizationSlug,
       projectsByOrganizationSlug: projectsByOrganizationSlug ?? this.projectsByOrganizationSlug,
       projectsFetchedOnce: projectsFetchedOnce ?? this.projectsFetchedOnce,
+      projectIdsWithSessions: projectIdsWithSessions ?? this.projectIdsWithSessions,
       projectsWithSessions: projectsWithSessions ?? this.projectsWithSessions,
       latestReleasesByProjectId: latestReleasesByProjectId ?? this.latestReleasesByProjectId,
       sessionsByProjectId: sessionsByProjectId ?? this.sessionsByProjectId,

--- a/lib/redux/state/app_state.dart
+++ b/lib/redux/state/app_state.dart
@@ -39,7 +39,7 @@ class GlobalState {
       this.projectCursorsByOrganizationSlug,
       this.projectsByOrganizationSlug,
       this.projectsFetchedOnce,
-      this.projects,
+      this.projectsWithSessions,
       this.latestReleasesByProjectId,
       this.sessionsByProjectId,
       this.sessionsBeforeByProjectId,
@@ -65,7 +65,7 @@ class GlobalState {
       projectCursorsByOrganizationSlug: {},
       projectsByOrganizationSlug: {},
       projectsFetchedOnce: false,
-      projects: [],
+      projectsWithSessions: [],
       latestReleasesByProjectId: {},
       sessionsByProjectId: {},
       sessionsBeforeByProjectId: {},
@@ -93,7 +93,7 @@ class GlobalState {
   final Map<String, List<Project>> projectsByOrganizationSlug;
   final bool projectsFetchedOnce;
 
-  final List<Project> projects;
+  final List<Project> projectsWithSessions;
   final Map<String, Release> latestReleasesByProjectId;
 
   final Map<String, Sessions> sessionsByProjectId;
@@ -124,7 +124,7 @@ class GlobalState {
     Map<String, List<Project>> projectsByOrganizationSlug,
     bool projectsFetchedOnce,
     bool projectsLoading,
-    List<Project> projects,
+    List<Project> projectsWithSessions,
     Map<String, Release> latestReleasesByProjectId,
     Map<String, Sessions> sessionsByProjectId,
     Map<String, Sessions> sessionsBeforeByProjectId,
@@ -149,7 +149,7 @@ class GlobalState {
       projectCursorsByOrganizationSlug: projectCursorsByOrganizationSlug ?? this.projectCursorsByOrganizationSlug,
       projectsByOrganizationSlug: projectsByOrganizationSlug ?? this.projectsByOrganizationSlug,
       projectsFetchedOnce: projectsFetchedOnce ?? this.projectsFetchedOnce,
-      projects: projects ?? this.projects,
+      projectsWithSessions: projectsWithSessions ?? this.projectsWithSessions,
       latestReleasesByProjectId: latestReleasesByProjectId ?? this.latestReleasesByProjectId,
       sessionsByProjectId: sessionsByProjectId ?? this.sessionsByProjectId,
       sessionsBeforeByProjectId: sessionsBeforeByProjectId ?? this.sessionsBeforeByProjectId,
@@ -243,6 +243,6 @@ class GlobalState {
   }
 
   List<ProjectWithLatestRelease> projectsWithLatestReleases() {
-    return projects.map((project) => ProjectWithLatestRelease(project, latestReleasesByProjectId[project.id])).toList();
+    return projectsWithSessions.map((project) => ProjectWithLatestRelease(project, latestReleasesByProjectId[project.id])).toList();
   }
 }

--- a/lib/screens/project_picker/project_picker.dart
+++ b/lib/screens/project_picker/project_picker.dart
@@ -34,16 +34,26 @@ class _ProjectPickerState extends State<ProjectPicker> {
         title: Text('Bookmarked Projects')
       ),
       body: ListView.builder(
-          itemCount: viewModel.items.length,
+          itemCount: viewModel.items.length + 1,
           itemBuilder: (context, index) {
-            final item = viewModel.items[index];
-            if (item is ProjectPickerOrganizationItem) {
+            if (index == 0) {
               return Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                  child: SettingsHeader(item.title)
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 20.0),
+                  child: Text(
+                    'Bookmarked project are shown before others on the main screen. '
+                    'Additionally, only projects with sessions in the last 90 days are shown.',
+                    style: Theme.of(context).textTheme.caption,
+                  )
               );
-            } else if (item is ProjectPickerProjectItem) {
-              return ListTile(
+            } else {
+              final item = viewModel.items[index - 1];
+              if (item is ProjectPickerOrganizationItem) {
+                return Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: SettingsHeader(item.title)
+                );
+              } else if (item is ProjectPickerProjectItem) {
+                return ListTile(
                   contentPadding: EdgeInsets.only(right: 16, top: 0, left: 16, bottom: 0),
                   title: Text(
                     item.title,
@@ -51,16 +61,18 @@ class _ProjectPickerState extends State<ProjectPicker> {
                         color: SentryColors.revolver
                     ),
                   ),
+                  subtitle: !item.hasSessions ? Text('No recent sessions.') : null,
                   trailing: Icon(
                     item.isBookmarked ? Icons.star : Icons.star_border,
                     color: item.isBookmarked ? SentryColors.lightningYellow : SentryColors.graySuit,
                   ),
-                onTap: () {
-                  viewModel.toggleBookmark(index);
-                },
-              );
-            } else {
-              throw Exception('Unknown list item type.');
+                  onTap: () {
+                    viewModel.toggleBookmark(index);
+                  },
+                );
+              } else {
+                throw Exception('Unknown list item type.');
+              }
             }
           }
       ),

--- a/lib/screens/project_picker/project_picker_item.dart
+++ b/lib/screens/project_picker/project_picker_item.dart
@@ -9,11 +9,12 @@ class ProjectPickerOrganizationItem extends ProjectPickerItem {
 }
 
 class ProjectPickerProjectItem extends ProjectPickerItem {
-  ProjectPickerProjectItem(this.organizationSlug, this.projectSlug, this.title, this.isBookmarked);
+  ProjectPickerProjectItem(this.organizationSlug, this.projectSlug, this.title, this.isBookmarked, this.hasSessions);
 
   final String organizationSlug;
   final String projectSlug;
 
   String title;
   bool isBookmarked;
+  bool hasSessions;
 }

--- a/lib/screens/project_picker/project_picker_view_model.dart
+++ b/lib/screens/project_picker/project_picker_view_model.dart
@@ -29,7 +29,8 @@ class ProjectPickerViewModel {
                 organization.slug,
                 organizationProject.slug,
                 organizationProject.slug,
-                organizationProject.isBookmarked
+                organizationProject.isBookmarked,
+                store.state.globalState.projectIdsWithSessions.contains(organizationProject.id)
               )
             );
           }

--- a/lib/screens/project_picker/project_picker_view_model.dart
+++ b/lib/screens/project_picker/project_picker_view_model.dart
@@ -1,5 +1,5 @@
 import 'package:redux/redux.dart';
-import 'package:sentry_mobile/redux/actions.dart';
+import '../../redux/actions.dart';
 import '../../redux/state/app_state.dart';
 import '../../types/organization.dart';
 import '../../types/project.dart';

--- a/lib/types/session_group_by.dart
+++ b/lib/types/session_group_by.dart
@@ -5,13 +5,17 @@ part 'session_group_by.g.dart';
 
 @JsonSerializable()
 class SessionGroupBy {
-  SessionGroupBy(this.sessionStatus);
+  SessionGroupBy(this.sessionStatus, this.project);
   factory SessionGroupBy.fromJson(Map<String, dynamic> json) => _$SessionGroupByFromJson(json);
 
   static const sessionStatusKey = 'session.status';
+  static const projectKey = 'project';
 
   @JsonKey(name: SessionGroupBy.sessionStatusKey)
   final SessionStatus sessionStatus;
+
+  @JsonKey(name: SessionGroupBy.projectKey)
+  final int project;
 
   Map<String, dynamic> toJson() => _$SessionGroupByToJson(this);
 }

--- a/lib/types/session_group_by.g.dart
+++ b/lib/types/session_group_by.g.dart
@@ -9,12 +9,14 @@ part of 'session_group_by.dart';
 SessionGroupBy _$SessionGroupByFromJson(Map<String, dynamic> json) {
   return SessionGroupBy(
     _$enumDecodeNullable(_$SessionStatusEnumMap, json['session.status']),
+    json['project'] as int,
   );
 }
 
 Map<String, dynamic> _$SessionGroupByToJson(SessionGroupBy instance) =>
     <String, dynamic>{
       'session.status': _$SessionStatusEnumMap[instance.sessionStatus],
+      'project': instance.project,
     };
 
 T _$enumDecode<T>(

--- a/test/util/stability_score_tests.dart
+++ b/test/util/stability_score_tests.dart
@@ -53,7 +53,7 @@ void main() {
 
 SessionGroup _givenSessionGroup(SessionStatus status, int num) {
   return SessionGroup(
-      SessionGroupBy(status),
+      SessionGroupBy(status, null),
       SessionGroupTotals(num, num),
       SessionGroupSeries([], [])
   );


### PR DESCRIPTION
# Overview

- Call `https://sentry.io/api/0/organizations/sentry-sdks/sessions/?project=-1&statsPeriod=90d&interval=90d&field=sum(session)&groupBy=project` to get projectss with sessions in the last 90 days.
- Only show those on the main screen.
- Show info for projects without sessions in settings.

Relates to #101 

# Assets

<img width="669" alt="Bildschirmfoto 2021-02-22 um 10 32 56" src="https://user-images.githubusercontent.com/3984453/108704652-9b454e80-750c-11eb-9984-c1596ac931ba.png">
