### PR TITLE
feat: Use session of past complete hours

### DIFF
--- a/lib/redux/middleware/sentry_api_middleware.dart
+++ b/lib/redux/middleware/sentry_api_middleware.dart
@@ -150,7 +150,9 @@ class SentryApiMiddleware extends MiddlewareClass<AppState> {
               organizationSlug: action.organizationSlug,
               projectId: action.projectId,
               fields: [SessionGroup.sumSessionKey, SessionGroup.countUniqueUsersKey],
-              groupBy: SessionGroupBy.sessionStatusKey
+              groupBy: SessionGroupBy.sessionStatusKey,
+              statsPeriodStart: '25h',
+              statsPeriodEnd: '1h'
           );
 
           final sessionsBefore = await api.sessions(
@@ -158,8 +160,8 @@ class SentryApiMiddleware extends MiddlewareClass<AppState> {
               projectId: action.projectId,
               fields: [SessionGroup.sumSessionKey, SessionGroup.countUniqueUsersKey],
               groupBy: SessionGroupBy.sessionStatusKey,
-              statsPeriodStart: '48h',
-              statsPeriodEnd: '24h'
+              statsPeriodStart: '49h',
+              statsPeriodEnd: '25h'
           );
 
           store.dispatch(


### PR DESCRIPTION
We want to use the session data of already fully passed hours to prevent the charts from initially always going down on the right (since the hour is never complete and we query data).

Before:
![CleanShot 2021-02-24 at 09 43 34](https://user-images.githubusercontent.com/363802/108973914-3a8d5180-7685-11eb-9919-8bb66bb66672.png)
After:

![CleanShot 2021-02-24 at 09 44 14](https://user-images.githubusercontent.com/363802/108973930-3cefab80-7685-11eb-991e-6d5aa6b18812.png)

