### PR TITLE
fix: Don't lint release builds

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -37,6 +37,7 @@ android {
 
     lintOptions {
         disable 'InvalidPackage'
+        checkReleaseBuilds false
     }
 
     defaultConfig {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 0.1.0+13
+version: 0.1.0+14
 
 environment:
   sdk: ">=2.8.0 <3.0.0"


### PR DESCRIPTION
Updating `gradle` tools might change lint rules. Disabling for now, so we can build release test APKs.