### PR TITLE
fix: Preserve project index on pull to refresh

### DIFF
--- a/lib/redux/actions.dart
+++ b/lib/redux/actions.dart
@@ -40,8 +40,8 @@ class ApiFailureAction {
 // FetchOrganizationsAndProjects
 
 class FetchOrgsAndProjectsAction {
-  FetchOrgsAndProjectsAction(this.reload);
-  final bool reload;
+  FetchOrgsAndProjectsAction(this.resetSessionData);
+  final bool resetSessionData;
 }
 
 class FetchOrgsAndProjectsProgressAction {

--- a/lib/redux/reducers.dart
+++ b/lib/redux/reducers.dart
@@ -63,7 +63,7 @@ GlobalState _logoutAction(GlobalState state, LogoutAction action) {
 }
 
 GlobalState _fetchOrganizationsAndProjectsAction(GlobalState state, FetchOrgsAndProjectsAction action) {
-  if (action.reload) {
+  if (action.resetSessionData) {
     return state.copyWith(
       sessionsByProjectId: {},
       sessionsBeforeByProjectId: {},

--- a/lib/screens/health/health_screen.dart
+++ b/lib/screens/health/health_screen.dart
@@ -79,7 +79,7 @@ class _HealthScreenState extends State<HealthScreen> {
         _index = index;
       };
 
-      if (_index == null) {
+      if (_index == null || _index >= viewModel.projects.length) {
         updateIndex(0);
       }
 
@@ -180,10 +180,11 @@ class _HealthScreenState extends State<HealthScreen> {
           Duration(microseconds: 100),
           () {
             viewModel.reloadProjects();
-            setState(() {
-              updateIndex(0);
-              _pageController.jumpToPage(0);
-            });
+
+            // Reload session data for previous, current and next index.
+            viewModel.fetchDataForProject(_index - 1);
+            viewModel.fetchDataForProject(_index);
+            viewModel.fetchDataForProject(_index + 1);
           }
         ),
       );

--- a/lib/screens/health/health_screen_view_model.dart
+++ b/lib/screens/health/health_screen_view_model.dart
@@ -122,6 +122,9 @@ class HealthScreenViewModel {
   }
   
   void fetchDataForProject(int index) {
+    if (index < 0 || index >= projects.length) {
+      return;
+    }
     final projectWithLatestRelease = projects[index];
     //_fetchLatestRelease(projectWithLatestRelease);
     _fetchSessions(projectWithLatestRelease);


### PR DESCRIPTION
# Overview

- Preserve index
- Fetch session data for previous, current and next project

/cc @bruno-garcia 