### PR TITLE
feat: Add Sentry fastlane step for IPA upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Provide environment variables needed for fastlane. For example by updating your 
 export FASTLANE_USER="user@sentry.io"
 export FASTLANE_ITC_TEAM_ID="12345678" # The identifier of the iTunes Connect (AppStore Connect) team
 export FASTLANE_PROVISIONING_PROFILE_NAME="Profile For Appstore" # The name of the provisioning profile
+export SENTRY_AUTH_TOKEN="Sentry AuthToken" # Used iOS dsym upload
 ```
 
 Change working directory to 'ios' and run 'fastlane build_ios_and_upload_ipa'.
@@ -65,6 +66,12 @@ The build number from the current TestFlight build will be read and incremented 
 ```
 cd ios
 fastlane build_ios_and_upload_ipa
+```
+
+After the build finished processing, you can fetch the latest dsyms and upload them to Sentry.
+
+```
+fastlane upload_dsym
 ```
 
 # Build Android and Upload to Google Play Internal

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cd ios
 fastlane build_ios_and_upload_ipa
 ```
 
-After the build finished processing, you can fetch the latest dsyms and upload them to Sentry.
+After the build finished processing, you can fetch the latest dsyms and upload them to Sentry. For this, you need to install the fastlane plugin first https://github.com/getsentry/sentry-fastlane-plugin
 
 ```
 fastlane upload_dsym

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -108,7 +108,7 @@ platform :ios do
 		)
 		sentry_upload_dsym(
 			auth_token: ENV['SENTRY_AUTH_TOKEN'],
-			org_slug: 'sentry-sdks',
+			org_slug: 'sentry',
 			project_slug: 'sentry-mobile',
 			dsym_path: 'fastlane/dsym'
 		)

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -99,6 +99,20 @@ platform :ios do
 		build_ipa()
 		upload_ipa()
 	end
+
+	desc "Upload current dsym to sentry.io"
+	lane :upload_dsym do
+		download_dsyms(
+			version: "latest",
+			output_directory: "fastlane/dsym"
+		)
+		sentry_upload_dsym(
+			auth_token: ENV['SENTRY_AUTH_TOKEN'],
+			org_slug: 'sentry-sdks',
+			project_slug: 'sentry-mobile',
+			dsym_path: 'fastlane/dsym'
+		)
+	end
 end
 
 # Helper


### PR DESCRIPTION
# Overview

- Add a `fastlane` step to upload DSYMs of the most recent TestFlight build.

- [x] Set correct org slug.