### PR TITLE
Fix: Interval in sessions call

### DIFF
--- a/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Runner.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/lib/api/sentry_api.dart
+++ b/lib/api/sentry_api.dart
@@ -57,7 +57,7 @@ class SentryApi {
   Future<Set<String>>projectIdsWithSessions(String organizationSlug) async {
     final queryParameters = <String, dynamic>{ /*String|Iterable<String>*/
       'project': '-1',
-      'interval': '90d',
+      'interval': '1d',
       'statsPeriod': '90d',
       'field': SessionGroup.sumSessionKey,
       'groupBy': SessionGroupBy.projectKey

--- a/lib/screens/health/health_screen_view_model.dart
+++ b/lib/screens/health/health_screen_view_model.dart
@@ -23,8 +23,8 @@ class HealthScreenViewModel {
       _crashFreeUsersBeforeByProjectId = store.state.globalState.crashFreeUsersBeforeByProjectId,
       _apdexByProjectId = store.state.globalState.apdexByProjectId,
       _apdexBeforeByProjectId = store.state.globalState.apdexBeforeByProjectId,
-      showProjectEmptyScreen = store.state.globalState.projectsWithLatestReleases().isEmpty && !store.state.globalState.orgsAndProjectsLoading,
-      showLoadingScreen = store.state.globalState.projectsWithLatestReleases().isEmpty && store.state.globalState.orgsAndProjectsLoading,
+      showProjectEmptyScreen = store.state.globalState.projectsWithSessions.isEmpty && !store.state.globalState.orgsAndProjectsLoading,
+      showLoadingScreen = store.state.globalState.projectsWithSessions.isEmpty && store.state.globalState.orgsAndProjectsLoading,
       showErrorScreen = store.state.globalState.orgsAndProjectsError,
       loadingProgress = store.state.globalState.orgsAndProjectsProgress,
       loadingText = store.state.globalState.orgsAndProjectsProgressText;

--- a/lib/screens/health/health_screen_view_model.dart
+++ b/lib/screens/health/health_screen_view_model.dart
@@ -23,8 +23,8 @@ class HealthScreenViewModel {
       _crashFreeUsersBeforeByProjectId = store.state.globalState.crashFreeUsersBeforeByProjectId,
       _apdexByProjectId = store.state.globalState.apdexByProjectId,
       _apdexBeforeByProjectId = store.state.globalState.apdexBeforeByProjectId,
-      showProjectEmptyScreen = store.state.globalState.projectsByOrganizationSlug.keys.isEmpty && !store.state.globalState.orgsAndProjectsLoading,
-      showLoadingScreen = store.state.globalState.projectsByOrganizationSlug.keys.isEmpty && store.state.globalState.orgsAndProjectsLoading,
+      showProjectEmptyScreen = store.state.globalState.projectsWithLatestReleases().isEmpty && !store.state.globalState.orgsAndProjectsLoading,
+      showLoadingScreen = store.state.globalState.projectsWithLatestReleases().isEmpty && store.state.globalState.orgsAndProjectsLoading,
       showErrorScreen = store.state.globalState.orgsAndProjectsError,
       loadingProgress = store.state.globalState.orgsAndProjectsProgress,
       loadingText = store.state.globalState.orgsAndProjectsProgressText;


### PR DESCRIPTION
# Overview

- Use `1d` as interval in sessions call instead of `90d`
- Use correct data structure for empty screen

Closes #164
Closes #166