### PR TITLE
Fix: Don't fetch user without authToken

### DIFF
--- a/lib/redux/actions.dart
+++ b/lib/redux/actions.dart
@@ -118,7 +118,8 @@ class FetchIssuesFailureAction extends ApiFailureAction {
 // FetchAuthenticatedUser
 
 class FetchAuthenticatedUserAction {
-  FetchAuthenticatedUserAction();
+  FetchAuthenticatedUserAction(this.authToken);
+  final String authToken;
 }
 
 class FetchAuthenticatedUserSuccessAction {

--- a/lib/redux/middleware/local_storage_middleware.dart
+++ b/lib/redux/middleware/local_storage_middleware.dart
@@ -28,7 +28,7 @@ class LocalStorageMiddleware extends MiddlewareClass<AppState> {
 
       store.dispatch(RehydrateSuccessAction(authToken, sentrySdkEnabled, version));
       if (authToken != null) {
-        store.dispatch(FetchAuthenticatedUserAction());
+        store.dispatch(FetchAuthenticatedUserAction(authToken));
       }
     }
     if (action is SentrySdkToggleAction) {
@@ -40,7 +40,7 @@ class LocalStorageMiddleware extends MiddlewareClass<AppState> {
     }
     if (action is LoginSuccessAction) {
       await secureStorage.write(key: _keyAuthToken, value: action.authToken);
-      store.dispatch(FetchAuthenticatedUserAction());
+      store.dispatch(FetchAuthenticatedUserAction(action.authToken));
     }
     if (action is LogoutAction) {
       await secureStorage.delete(key: _keyAuthToken);

--- a/lib/redux/middleware/sentry_api_middleware.dart
+++ b/lib/redux/middleware/sentry_api_middleware.dart
@@ -120,7 +120,7 @@ class SentryApiMiddleware extends MiddlewareClass<AppState> {
       store.dispatch(thunkAction);
     } else if (action is FetchAuthenticatedUserAction) {
       final thunkAction = (Store<AppState> store) async {
-        final api = SentryApi(store.state.globalState.authToken);
+        final api = SentryApi(store.state.globalState.authToken ?? action.authToken);
         try {
           final me = await api.authenticatedUser();
           store.dispatch(

--- a/lib/screens/settings/settings_view_model.dart
+++ b/lib/screens/settings/settings_view_model.dart
@@ -29,7 +29,7 @@ class SettingsViewModel {
 
   void fetchAuthenticatedUserIfNeeded() {
     if (_store.state.globalState.me == null) {
-      _store.dispatch(FetchAuthenticatedUserAction());
+      _store.dispatch(FetchAuthenticatedUserAction(_store.state.globalState.authToken));
     }
   }
 }


### PR DESCRIPTION
# Overview

- On first app start, tehe action to fetch the user is done before the auth token is present in the global state.
- Add the auth token to the action payload and use it as fallback.