### PR TITLE
Don't rethrow known 400er error

### DIFF
--- a/lib/redux/middleware/sentry_api_middleware.dart
+++ b/lib/redux/middleware/sentry_api_middleware.dart
@@ -1,5 +1,6 @@
 import 'package:redux/redux.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
+import 'package:sentry_mobile/api/api_errors.dart';
 
 import '../../api/sentry_api.dart';
 import '../../types/group.dart';
@@ -42,8 +43,11 @@ class SentryApiMiddleware extends MiddlewareClass<AppState> {
               final projectsWithSessionsForOrganization = await api.projectIdsWithSessions(organization.slug);
               projectIdsWithSessions.addAll(projectsWithSessionsForOrganization);
             } catch (e) {
-              Sentry.addBreadcrumb(Breadcrumb(message: 'Org has no projects -> $e', level: SentryLevel.error));
-              rethrow;
+              if (e is ApiError && e.statusCode == 400) {
+                Sentry.addBreadcrumb(Breadcrumb(message: 'Org has no projects -> $e', level: SentryLevel.error));
+              } else {
+                rethrow;
+              }
             }
           }
           store.dispatch(FetchOrgsAndProjectsSuccessAction(individualOrganizations, projectsByOrganizationId, projectIdsWithSessions));


### PR DESCRIPTION
@HazAT We ignore the 400er again error when fetching projects for org, but show the error screen for others.