### PR TITLE
feat: Manual Tracing - Idle Transaction

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -12,13 +12,13 @@ PODS:
   - qr_code_scanner (0.2.0):
     - Flutter
     - MTBBarcodeScanner
-  - Sentry (7.2.10):
-    - Sentry/Core (= 7.2.10)
-  - Sentry/Core (7.2.10)
+  - Sentry (7.5.2):
+    - Sentry/Core (= 7.5.2)
+  - Sentry/Core (7.5.2)
   - sentry_flutter (0.0.1):
     - Flutter
     - FlutterMacOS
-    - Sentry (~> 7.2.7)
+    - Sentry (~> 7.5.1)
   - shared_preferences (0.0.1):
     - Flutter
   - url_launcher (0.0.1):
@@ -68,8 +68,8 @@ SPEC CHECKSUMS:
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
-  Sentry: 013d45af76b45749e3b646809eee3320bb209fca
-  sentry_flutter: 28e1e38fe797d3e5d766c596324834fed599bc0f
+  Sentry: 95788d2baa9cc904151c9ac41101c67d9f25e09e
+  sentry_flutter: 4cd99764f9fe01c9415790d1f3fb1c7fd3a5cbe9
   shared_preferences: af6bfa751691cdc24be3045c43ec037377ada40d
   url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef
 

--- a/lib/api/sentry_api.dart
+++ b/lib/api/sentry_api.dart
@@ -24,6 +24,7 @@ class SentryApi {
     captureFailedRequests: true,
     sendDefaultPii: false,
     failedRequestStatusCodes: [sentry.SentryStatusCode.range(400, 599)],
+    networkTracing: true,
   );
   final baseUrlName = 'sentry.io';
   final baseUrlPath = '/api/0';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'redux/middleware/shared_preferences_middleware.dart';
 import 'redux/reducers.dart';
 import 'redux/state/app_state.dart';
 import 'screens/main/main_screen.dart';
+import 'screens/navigation/SentryMobileNavigationObserver.dart';
 import 'screens/onboarding/onboarding_screen.dart';
 import 'screens/splash/splash_screen.dart';
 import 'utils/sentry_colors.dart';
@@ -151,7 +152,10 @@ class SentryMobile extends StatelessWidget {
           }
         },
       ),
-      navigatorObservers: [SentryNavigatorObserver()],
+      navigatorObservers: [
+        SentryNavigatorObserver(),
+        SentryMobileRouteObserver(),
+      ],
     );
   }
 }

--- a/lib/redux/middleware/sentry_api_middleware.dart
+++ b/lib/redux/middleware/sentry_api_middleware.dart
@@ -17,7 +17,6 @@ class SentryApiMiddleware extends MiddlewareClass<AppState> {
   dynamic call(Store<AppState> store, action, next) {
     if (action is FetchOrgsAndProjectsAction) {
       final thunkAction = (Store<AppState> store) async {
-
         final syncSpan = Sentry.getSpan()?.startChild(
           'ui.load',
           description: 'Sync organizations and projects in multi-step process.',
@@ -67,9 +66,9 @@ class SentryApiMiddleware extends MiddlewareClass<AppState> {
             }
           }
           store.dispatch(FetchOrgsAndProjectsSuccessAction(
-              individualOrganizations,
-              projectsByOrganizationId,
-              projectIdsWithSessions,
+            individualOrganizations,
+            projectsByOrganizationId,
+            projectIdsWithSessions,
           ));
           syncSpan?.status ??= SpanStatus.ok();
         } catch (e, s) {

--- a/lib/redux/middleware/sentry_api_middleware.dart
+++ b/lib/redux/middleware/sentry_api_middleware.dart
@@ -17,6 +17,12 @@ class SentryApiMiddleware extends MiddlewareClass<AppState> {
   dynamic call(Store<AppState> store, action, next) {
     if (action is FetchOrgsAndProjectsAction) {
       final thunkAction = (Store<AppState> store) async {
+
+        final syncSpan = Sentry.getSpan()?.startChild(
+          'ui.load',
+          description: 'Sync organizations and projects in multi-step process.',
+        );
+
         final api = SentryApi(store.state.globalState.authToken);
         try {
           store.dispatch(FetchOrgsAndProjectsProgressAction(
@@ -63,9 +69,15 @@ class SentryApiMiddleware extends MiddlewareClass<AppState> {
           store.dispatch(FetchOrgsAndProjectsSuccessAction(
               individualOrganizations,
               projectsByOrganizationId,
-              projectIdsWithSessions));
+              projectIdsWithSessions,
+          ));
+          syncSpan?.status ??= SpanStatus.ok();
         } catch (e, s) {
+          syncSpan?.throwable = e;
+          syncSpan?.status = SpanStatus.internalError();
           store.dispatch(FetchOrgsAndProjectsFailureAction(e, s));
+        } finally {
+          syncSpan?.finish();
         }
         api.close();
       };

--- a/lib/redux/middleware/sentry_sdk_middleware.dart
+++ b/lib/redux/middleware/sentry_sdk_middleware.dart
@@ -58,6 +58,11 @@ class SentrySdkMiddleware extends MiddlewareClass<AppState> {
       // as a not in app frame.
       options.addInAppInclude('sentry_mobile');
       options.considerInAppFramesByDefault = false;
+      if (kReleaseMode) {
+        options.tracesSampleRate = 0.1;
+      } else {
+        options.tracesSampleRate = 1.0;
+      }
     });
   }
 

--- a/lib/screens/connect/connect_screen.dart
+++ b/lib/screens/connect/connect_screen.dart
@@ -134,7 +134,10 @@ class _ConnectScreenState extends State<ConnectScreen> {
 
   Future<String?> _presentScannerScreen() async {
     return await Navigator.of(context).push(
-      MaterialPageRoute(builder: (BuildContext context) => ScannerScreen()),
+      MaterialPageRoute(
+        builder: (BuildContext context) => ScannerScreen(),
+        settings: RouteSettings(name: 'ScannerScreen'),
+      ),
     ) as String?;
   }
 

--- a/lib/screens/main/main_app_bar.dart
+++ b/lib/screens/main/main_app_bar.dart
@@ -51,7 +51,10 @@ class MainAppBar extends StatelessWidget with PreferredSizeWidget {
 
   Future<void> _pushSettings(BuildContext context) async {
     final bool? logout = await Navigator.of(context).push(
-      MaterialPageRoute(builder: (BuildContext context) => Settings()),
+      MaterialPageRoute(
+          builder: (BuildContext context) => Settings(),
+          settings: RouteSettings(name: 'Settings'),
+      ),
     );
     if (logout == true) {
       StoreProvider.of<AppState>(context).dispatch(LogoutAction());

--- a/lib/screens/main/main_app_bar.dart
+++ b/lib/screens/main/main_app_bar.dart
@@ -52,8 +52,8 @@ class MainAppBar extends StatelessWidget with PreferredSizeWidget {
   Future<void> _pushSettings(BuildContext context) async {
     final bool? logout = await Navigator.of(context).push(
       MaterialPageRoute(
-          builder: (BuildContext context) => Settings(),
-          settings: RouteSettings(name: 'Settings'),
+        builder: (BuildContext context) => Settings(),
+        settings: RouteSettings(name: 'Settings'),
       ),
     );
     if (logout == true) {

--- a/lib/screens/navigation/SentryMobileNavigationObserver.dart
+++ b/lib/screens/navigation/SentryMobileNavigationObserver.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 
 import 'package:flutter/widgets.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
@@ -5,6 +6,7 @@ import 'package:sentry_flutter/sentry_flutter.dart';
 class SentryMobileRouteObserver extends RouteObserver<PageRoute<dynamic>> {
 
   ISentrySpan? _transaction;
+  Timer? _idleTimer;
 
   @override
   void didPush(Route route, Route? previousRoute) {
@@ -22,12 +24,14 @@ class SentryMobileRouteObserver extends RouteObserver<PageRoute<dynamic>> {
     if (arguments != null) {
       _transaction?.setData('route_settings_arguments', arguments);
     }
-    Future.delayed(Duration(seconds: 2), () async {
+
+    _idleTimer = Timer(Duration(seconds: 3), () async {
       await _finishTransaction();
     });
   }
 
   Future<void> _finishTransaction() async {
+    _idleTimer?.cancel();
     _transaction?.status ??= SpanStatus.ok();
     return await _transaction?.finish();
   }

--- a/lib/screens/navigation/SentryMobileNavigationObserver.dart
+++ b/lib/screens/navigation/SentryMobileNavigationObserver.dart
@@ -4,7 +4,6 @@ import 'package:flutter/widgets.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
 class SentryMobileRouteObserver extends RouteObserver<PageRoute<dynamic>> {
-
   ISentrySpan? _transaction;
   Timer? _idleTimer;
 

--- a/lib/screens/navigation/SentryMobileNavigationObserver.dart
+++ b/lib/screens/navigation/SentryMobileNavigationObserver.dart
@@ -1,0 +1,34 @@
+
+import 'package:flutter/widgets.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+class SentryMobileRouteObserver extends RouteObserver<PageRoute<dynamic>> {
+
+  ISentrySpan? _transaction;
+
+  @override
+  void didPush(Route route, Route? previousRoute) {
+    _finishTransaction();
+    _startTransaction(route.settings.name, route.settings.arguments);
+    super.didPush(route, previousRoute);
+  }
+
+  void _startTransaction(String? name, Object? arguments) {
+    _transaction = Sentry.startTransaction(
+      name ?? 'unknown',
+      'ui.load',
+      bindToScope: true,
+    );
+    if (arguments != null) {
+      _transaction?.setData('route_settings_arguments', arguments);
+    }
+    Future.delayed(Duration(seconds: 2), () async {
+      await _finishTransaction();
+    });
+  }
+
+  Future<void> _finishTransaction() async {
+    _transaction?.status ??= SpanStatus.ok();
+    return await _transaction?.finish();
+  }
+}

--- a/lib/screens/navigation/SentryMobileNavigationObserver.dart
+++ b/lib/screens/navigation/SentryMobileNavigationObserver.dart
@@ -9,9 +9,15 @@ class SentryMobileRouteObserver extends RouteObserver<PageRoute<dynamic>> {
 
   @override
   void didPush(Route route, Route? previousRoute) {
+    super.didPush(route, previousRoute);
     _finishTransaction();
     _startTransaction(route.settings.name, route.settings.arguments);
-    super.didPush(route, previousRoute);
+  }
+
+  @override
+  void didPop(Route route, Route? previousRoute) {
+    _finishTransaction();
+    super.didPop(route, previousRoute);
   }
 
   void _startTransaction(String? name, Object? arguments) {

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -142,9 +142,10 @@ class _SettingsState extends State<Settings> {
                   onTap: () {
                     Navigator.of(context).push(
                       MaterialPageRoute(
-                          builder: (BuildContext context) =>
-                              LicenseScreen(viewModel.version),
-                        settings: RouteSettings(name: 'LicenseScreen'),),
+                        builder: (BuildContext context) =>
+                            LicenseScreen(viewModel.version),
+                        settings: RouteSettings(name: 'LicenseScreen'),
+                      ),
                     );
                   }),
               Padding(
@@ -218,7 +219,8 @@ class _SettingsState extends State<Settings> {
                           MaterialPageRoute(
                             fullscreenDialog: true,
                             builder: (context) => SentryFlutterScreen(),
-                            settings: RouteSettings(name: 'SentryFlutterScreen'),
+                            settings:
+                                RouteSettings(name: 'SentryFlutterScreen'),
                           ),
                         );
                       },

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -66,7 +66,9 @@ class _SettingsState extends State<Settings> {
                 ),
                 onTap: () => Navigator.of(context).push(
                   MaterialPageRoute(
-                      builder: (BuildContext context) => ProjectsScreen()),
+                    builder: (BuildContext context) => ProjectsScreen(),
+                    settings: RouteSettings(name: 'ProjectsScreen'),
+                  ),
                 ),
               ),
               Padding(
@@ -116,9 +118,13 @@ class _SettingsState extends State<Settings> {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                          fullscreenDialog: true,
-                          builder: (context) => HtmlScreen(
-                              'End User License Agreement', eulaFilePath)),
+                        fullscreenDialog: true,
+                        builder: (context) => HtmlScreen(
+                          'End User License Agreement',
+                          eulaFilePath,
+                        ),
+                        settings: RouteSettings(name: 'HtmlScreen'),
+                      ),
                     );
                   }),
               ListTile(
@@ -137,7 +143,8 @@ class _SettingsState extends State<Settings> {
                     Navigator.of(context).push(
                       MaterialPageRoute(
                           builder: (BuildContext context) =>
-                              LicenseScreen(viewModel.version)),
+                              LicenseScreen(viewModel.version),
+                        settings: RouteSettings(name: 'LicenseScreen'),),
                     );
                   }),
               Padding(
@@ -209,8 +216,10 @@ class _SettingsState extends State<Settings> {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                              fullscreenDialog: true,
-                              builder: (context) => SentryFlutterScreen()),
+                            fullscreenDialog: true,
+                            builder: (context) => SentryFlutterScreen(),
+                            settings: RouteSettings(name: 'SentryFlutterScreen'),
+                          ),
                         );
                       },
                       child: Text(viewModel.version,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -610,14 +610,14 @@ packages:
       name: sentry
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "6.1.2"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "6.1.2"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   qr_code_scanner: 0.5.1
   redux: ^5.0.0
   redux_thunk: ^0.4.0
-  sentry_flutter: ^6.0.0
+  sentry_flutter: ^6.1.0
   shared_preferences: ^2.0.6
   timeago: ^3.1.0
   url_launcher: ^6.0.9


### PR DESCRIPTION
# Overview

Add a `RouteObserver` where transactions are started when new routes get pushed. They are finished after a fixed duration idle timer finished, when a new route is pushed, or when a route is popped.

It's mainly based on the feedback of you @ueman in #220 and your work [here](https://github.com/getsentry/sentry-dart/pull/611), thank you again!

# Implementation

- Create a transaction when a new route is pushed.
- Finish previous transaction when a new one is pushed.
- Finish transactions automatically after three seconds. Child spans do **not** prolong this idle time.
- Transactions are only created when pushed, so the initial root transaction with name "/" is only started and finished once.

# Other/Discussion

- Users would need to provide `RouteSettings` with a name parameter in `MaterialPageRoute` if this wer part of the SDK.
- Added a child span to multi step sync.
- Should we also re-start transactions when going back to a route?
- Should we handle Popups or Modals differently?
- Can't seem to find `/` main route on `sentry.io`. Is this an invalid name?
- Child operations/http calls that take longer than the idle timeout may not be be associated with the transaction.

# Screenshots

<img width="1423" alt="Screenshot 2021-11-18 at 15 32 03" src="https://user-images.githubusercontent.com/3984453/142435504-ec0fd485-98bb-41d0-996d-e5b4e8e09227.png">


