### PR TITLE
Feat: Use SentryNavigator

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -12,13 +12,13 @@ PODS:
   - qr_code_scanner (0.2.0):
     - Flutter
     - MTBBarcodeScanner
-  - Sentry (7.2.10):
-    - Sentry/Core (= 7.2.10)
-  - Sentry/Core (7.2.10)
+  - Sentry (7.5.4):
+    - Sentry/Core (= 7.5.4)
+  - Sentry/Core (7.5.4)
   - sentry_flutter (0.0.1):
     - Flutter
     - FlutterMacOS
-    - Sentry (~> 7.2.7)
+    - Sentry (~> 7.5.1)
   - shared_preferences (0.0.1):
     - Flutter
   - url_launcher (0.0.1):
@@ -68,8 +68,8 @@ SPEC CHECKSUMS:
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
-  Sentry: 013d45af76b45749e3b646809eee3320bb209fca
-  sentry_flutter: 28e1e38fe797d3e5d766c596324834fed599bc0f
+  Sentry: 5c5dd4005f3b7b9765d5a8871232cddbd0d888b7
+  sentry_flutter: 4cd99764f9fe01c9415790d1f3fb1c7fd3a5cbe9
   shared_preferences: af6bfa751691cdc24be3045c43ec037377ada40d
   url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef
 

--- a/lib/api/sentry_api.dart
+++ b/lib/api/sentry_api.dart
@@ -24,6 +24,7 @@ class SentryApi {
     captureFailedRequests: true,
     sendDefaultPii: false,
     failedRequestStatusCodes: [sentry.SentryStatusCode.range(400, 599)],
+    networkTracing: true,
   );
   final baseUrlName = 'sentry.io';
   final baseUrlPath = '/api/0';

--- a/lib/redux/middleware/sentry_sdk_middleware.dart
+++ b/lib/redux/middleware/sentry_sdk_middleware.dart
@@ -58,6 +58,11 @@ class SentrySdkMiddleware extends MiddlewareClass<AppState> {
       // as a not in app frame.
       options.addInAppInclude('sentry_mobile');
       options.considerInAppFramesByDefault = false;
+      if (kReleaseMode) {
+        options.tracesSampleRate = 0.1;
+      } else {
+        options.tracesSampleRate = 1.0;
+      }
     });
   }
 

--- a/lib/screens/chart/line_chart.dart
+++ b/lib/screens/chart/line_chart.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';

--- a/lib/screens/connect/connect_screen.dart
+++ b/lib/screens/connect/connect_screen.dart
@@ -134,7 +134,10 @@ class _ConnectScreenState extends State<ConnectScreen> {
 
   Future<String?> _presentScannerScreen() async {
     return await Navigator.of(context).push(
-      MaterialPageRoute(builder: (BuildContext context) => ScannerScreen()),
+      MaterialPageRoute(
+        builder: (BuildContext context) => ScannerScreen(),
+        settings: RouteSettings(name: 'ScannerScreen'),
+      ),
     ) as String?;
   }
 

--- a/lib/screens/health/project_card.dart
+++ b/lib/screens/health/project_card.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 
 import '../../redux/state/session_state.dart';
 import '../../types/project.dart';

--- a/lib/screens/main/main_app_bar.dart
+++ b/lib/screens/main/main_app_bar.dart
@@ -51,7 +51,10 @@ class MainAppBar extends StatelessWidget with PreferredSizeWidget {
 
   Future<void> _pushSettings(BuildContext context) async {
     final bool? logout = await Navigator.of(context).push(
-      MaterialPageRoute(builder: (BuildContext context) => Settings()),
+      MaterialPageRoute(
+        builder: (BuildContext context) => Settings(),
+        settings: RouteSettings(name: 'Settings'),
+      ),
     );
     if (logout == true) {
       StoreProvider.of<AppState>(context).dispatch(LogoutAction());

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -66,7 +66,9 @@ class _SettingsState extends State<Settings> {
                 ),
                 onTap: () => Navigator.of(context).push(
                   MaterialPageRoute(
-                      builder: (BuildContext context) => ProjectsScreen()),
+                    builder: (BuildContext context) => ProjectsScreen(),
+                    settings: RouteSettings(name: 'ProjectsScreen'),
+                  ),
                 ),
               ),
               Padding(
@@ -116,9 +118,13 @@ class _SettingsState extends State<Settings> {
                     Navigator.push(
                       context,
                       MaterialPageRoute(
-                          fullscreenDialog: true,
-                          builder: (context) => HtmlScreen(
-                              'End User License Agreement', eulaFilePath)),
+                        fullscreenDialog: true,
+                        builder: (context) => HtmlScreen(
+                          'End User License Agreement',
+                          eulaFilePath,
+                        ),
+                        settings: RouteSettings(name: 'HtmlScreen'),
+                      ),
                     );
                   }),
               ListTile(
@@ -136,8 +142,10 @@ class _SettingsState extends State<Settings> {
                   onTap: () {
                     Navigator.of(context).push(
                       MaterialPageRoute(
-                          builder: (BuildContext context) =>
-                              LicenseScreen(viewModel.version)),
+                        builder: (BuildContext context) =>
+                            LicenseScreen(viewModel.version),
+                        settings: RouteSettings(name: 'LicenseScreen'),
+                      ),
                     );
                   }),
               Padding(
@@ -209,8 +217,11 @@ class _SettingsState extends State<Settings> {
                         Navigator.push(
                           context,
                           MaterialPageRoute(
-                              fullscreenDialog: true,
-                              builder: (context) => SentryFlutterScreen()),
+                            fullscreenDialog: true,
+                            builder: (context) => SentryFlutterScreen(),
+                            settings:
+                            RouteSettings(name: 'SentryFlutterScreen'),
+                          ),
                         );
                       },
                       child: Text(viewModel.version,

--- a/lib/screens/settings/settings.dart
+++ b/lib/screens/settings/settings.dart
@@ -220,7 +220,7 @@ class _SettingsState extends State<Settings> {
                             fullscreenDialog: true,
                             builder: (context) => SentryFlutterScreen(),
                             settings:
-                            RouteSettings(name: 'SentryFlutterScreen'),
+                                RouteSettings(name: 'SentryFlutterScreen'),
                           ),
                         );
                       },

--- a/lib/utils/sentry_colors.dart
+++ b/lib/utils/sentry_colors.dart
@@ -1,4 +1,3 @@
-import 'dart:ui';
 import 'package:flutter/material.dart';
 
 // ignore: avoid_classes_with_only_static_members

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -105,7 +105,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -400,7 +400,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -610,14 +610,14 @@ packages:
       name: sentry
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "6.3.0-alpha.1"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "6.3.0-alpha.1"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -762,21 +762,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.10"
+    version: "1.17.12"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0"
+    version: "0.4.2"
   timeago:
     dependency: "direct main"
     description:
@@ -853,7 +853,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   vm_service:
     dependency: transitive
     description:
@@ -911,5 +911,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.13.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
   qr_code_scanner: 0.5.1
   redux: ^5.0.0
   redux_thunk: ^0.4.0
-  sentry_flutter: ^6.0.0
+  sentry_flutter: ^6.3.0-alpha.1
   shared_preferences: ^2.0.6
   timeago: ^3.1.0
   url_launcher: ^6.0.9


### PR DESCRIPTION
# Overview

Use sentry flutter alpha with auto tracing to dogfood our SDK.

- Enable `networkTracing`, so that child spans are automatically generated.
- Provide names in routing so that auto tracing kicks in.