### PR TITLE
Use Sentry Release github action to associate commit data with a release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,3 +49,7 @@ jobs:
             flutter build appbundle
             ;;
             esac
+        - name: Release
+          uses: getsentry/action-release@v1.1.6
+          with:
+            environment: 'production'


### PR DESCRIPTION
We're using the [Sentry Release github action](https://github.com/marketplace/actions/sentry-release) in various [internal projects](https://github.com/getsentry/eng-pipes/blob/main/.github/workflows/ci.yml#L173) to associate github commit data to a sentry release. 

Currently, the `sentry-mobile` project has appropriate [releases](https://sentry.io/organizations/sentry/releases/?project=5645511), but each of those releases don't have the correct commit data. E.g. https://sentry.io/organizations/sentry/releases/io.sentry.mobile.app%401.1.0%2B37/commits/?project=5645511

The end-goal is to get suspect commits working for this project to tie this project together with features we have in sentry.

